### PR TITLE
fix: Handled loading the identity with empty access key id.

### DIFF
--- a/src/apis/source.rs
+++ b/src/apis/source.rs
@@ -450,6 +450,9 @@ impl SourceAPI {
         &self,
         access_key_id: String,
     ) -> Result<Option<APIKey>, Box<dyn APIError>> {
+        if access_key_id.is_empty() {
+            return Ok(None);
+        }
         let client = reqwest::Client::new();
         let source_key = env::var("SOURCE_KEY").unwrap();
         let source_api_url = env::var("SOURCE_API_URL").unwrap();


### PR DESCRIPTION
#5 
This PR addresses the issues of accessing the API's with invalid authorization header, specifically the case where the access key id is empty.