### PR TITLE
fix: Handled the valid range header(start-) for boto3 download object request.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.1.16
+-------------
+
+* Handled the boto3 download object with range request pattern `start-` which is a valid request to fetch the bytes from start till the total bytes. 
+
 Version 0.1.15
 --------------
 * Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.rst`, Github issue templates, and Github pull request template.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "source-data-proxy"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,11 +67,13 @@ async fn get_object(
         if let Ok(r) = range_header.to_str() {
             if let Some(bytes_range) = r.strip_prefix("bytes=") {
                 if let Some((start, end)) = bytes_range.split_once('-') {
-                    if let (Ok(s), Ok(e)) = (start.parse::<u64>(), end.parse::<u64>()) {
+                    if let Ok(s) = start.parse::<u64>() {
                         range_start = s;
-                        range_end = e;
-                        range = Some(r.to_string());
-                        is_range_request = true;
+                        if end.is_empty() || end.parse::<u64>().is_ok() {
+                            range = Some(r.to_string());
+                            is_range_request = true;
+                            range_end = end.parse::<u64>().unwrap_or(u64::MAX);
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,6 @@ async fn get_object(
                         if end.is_empty() || end.parse::<u64>().is_ok() {
                             range = Some(r.to_string());
                             is_range_request = true;
-                            range_end = end.parse::<u64>().unwrap_or(u64::MAX);
                         }
                     }
                 }
@@ -139,7 +138,12 @@ async fn get_object(
                 if is_range_request {
                     response = response.insert_header((
                         "Content-Range",
-                        format!("bytes {}-{}/{}", range_start, range_end, content_length),
+                        format!(
+                            "bytes {}-{}/{}",
+                            range_start,
+                            range_start + res.content_length - 1,
+                            content_length
+                        ),
                     ));
                 }
 


### PR DESCRIPTION
Handled the boto3 download object with range request pattern `start-` which is a valid request to fetch the bytes from start till the total bytes. 


**Related Issue(s):** #
#7 

**Proposed Changes:**

1. Validation of end range to be either empty or a valid u64.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [x] This PR has **no** breaking changes.
- [x] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [x] I have updated the version in `Cargo.toml` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [x] All tests are passing.
- [x] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/data.source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
