### PR TITLE
v0.1.16

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.1.16
+-------------
+
+* Handled the boto3 download object with range request pattern `start-` which is a valid request to fetch the bytes from start till the total bytes. 
+
 Version 0.1.15
 --------------
 * Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.rst`, Github issue templates, and Github pull request template.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "source-data-proxy"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Source Cooperative Data Proxy v0.1.16

### Changelog

* Handled the boto3 download object with range request pattern `start-` which is a valid request to fetch the bytes from start till the total bytes.