### PR TITLE
fix: Fixed the issue in character encoding/decoding for request path.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 0.1.17
+--------------
+* Fixed the issue in request authorization. Decoded the request path before its encoded again. Not sure if the request path is originally encoded.
+
 Version 0.1.16
 -------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "source-data-proxy"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/utils/auth.rs
+++ b/src/utils/auth.rs
@@ -8,6 +8,7 @@ use actix_web::{
 use futures_util::{future::LocalBoxFuture, stream::StreamExt};
 use hex;
 use hmac::{Hmac, Mac};
+use percent_encoding::percent_decode_str;
 use sha2::{Digest, Sha256};
 use std::{
     borrow::Cow,
@@ -269,22 +270,22 @@ fn create_canonical_request(
     body: &BytesMut,
     content_hash: &str,
 ) -> String {
+    let decoded_path = percent_decode_str(path).decode_utf8().unwrap();
     if content_hash == "UNSIGNED-PAYLOAD" {
         return format!(
             "{}\n{}\n{}\n{}\n{}\n{}",
             method,
-            uri_encode(path, false),
+            uri_encode(decoded_path.as_ref(), false),
             get_canonical_query_string(query_string),
             get_canonical_headers(headers, &signed_headers),
             get_signed_headers(&signed_headers),
             content_hash
         );
     }
-
     format!(
         "{}\n{}\n{}\n{}\n{}\n{}",
         method,
-        uri_encode(path, false),
+        uri_encode(decoded_path.as_ref(), false),
         get_canonical_query_string(query_string),
         get_canonical_headers(headers, &signed_headers),
         get_signed_headers(&signed_headers),


### PR DESCRIPTION
**Related Issue(s):** #
#12 

**Proposed Changes:**

1. Decoded the path from request before encoding again. In case the request path is already encoded, we can avoid encoding again.
**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [x] This PR has **no** breaking changes.
- [x] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [x] I have updated the version in `Cargo.toml` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [x] All tests are passing.
- [x] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/data.source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
