### PR TITLE
fix: changed max keys to 1000 for list objects call.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ async fn list_objects(
 
     let (repository_id, prefix) = split_at_first_slash(&path_prefix);
 
-    let mut max_keys = NonZeroU32::new(1000).unwrap_or(NonZeroU32::new(1000).unwrap());
+    let mut max_keys = NonZeroU32::new(1000).unwrap();
     if let Some(mk) = info.max_keys {
         max_keys = mk;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ async fn list_objects(
 
     let (repository_id, prefix) = split_at_first_slash(&path_prefix);
 
-    let mut max_keys = NonZeroU32::new(20).unwrap_or(NonZeroU32::new(20).unwrap());
+    let mut max_keys = NonZeroU32::new(1000).unwrap_or(NonZeroU32::new(1000).unwrap());
     if let Some(mk) = info.max_keys {
         max_keys = mk;
     }


### PR DESCRIPTION
**Related Issue(s):** #
#22 

**Proposed Changes:**

1. Increased the max objects returned in a list objects call.
2.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [x] This PR has **no** breaking changes.
- [x] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [x] All tests are passing.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
