### PR TITLE
feat: Added api endpoint to list accounts of bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.20](https://github.com/source-cooperative/data.source.coop/compare/v0.1.19...v0.1.20) (2024-12-03)
+
+
+### Bug Fixes
+
+* Fixed the slow response of the ListObjects call. ([#32](https://github.com/source-cooperative/data.source.coop/issues/32)) ([6afcf13](https://github.com/source-cooperative/data.source.coop/commit/6afcf13ec15b9cc79f5d6a2aef55b3d269a14e16))
+
 ## [0.1.19](https://github.com/source-cooperative/data.source.coop/compare/v0.1.18...v0.1.19) (2024-11-28)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "source-data-proxy"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "source-data-proxy"
 
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/backends/azure.rs
+++ b/src/backends/azure.rs
@@ -328,4 +328,97 @@ impl Repository for AzureRepository {
 
         Ok(result)
     }
+
+    async fn list_buckets_accounts(
+        &self,
+        prefix: String,
+        continuation_token: Option<String>,
+        delimiter: Option<String>,
+        max_keys: NonZeroU32,
+    ) -> Result<ListBucketResult, Box<dyn APIError>> {
+        let mut result = ListBucketResult {
+            name: format!("{}", self.account_id),
+            prefix: prefix.clone(),
+            key_count: 0,
+            max_keys: 0,
+            is_truncated: false,
+            contents: vec![],
+            common_prefixes: vec![],
+            next_continuation_token: None,
+        };
+
+        let credentials = StorageCredentials::anonymous();
+
+        // Create a client for anonymous access
+        let client = BlobServiceClient::new(format!("{}", &self.account_name), credentials)
+            .container_client(&self.container_name);
+        let search_prefix = format!("{}/{}", self.base_prefix.trim_end_matches('/'), prefix);
+
+        let next_marker = continuation_token.map_or(NextMarker::new("".to_string()), Into::into);
+
+        let query_delmiter = delimiter.unwrap_or_else(|| "".to_string());
+
+        // List blobs
+        let mut stream = client
+            .list_blobs()
+            .marker(next_marker)
+            .prefix(search_prefix)
+            .max_results(max_keys)
+            .delimiter(query_delmiter)
+            .into_stream();
+
+        if let Some(blob_result) = stream.next().await {
+            match blob_result {
+                Ok(blob) => {
+                    if blob.max_results.is_some() {
+                        result.max_keys = blob.max_results.unwrap() as i64;
+                    }
+
+                    if blob.next_marker.is_some() {
+                        result.is_truncated = true;
+                        result.next_continuation_token = Some(
+                            blob.next_marker
+                                .unwrap_or(NextMarker::new("".to_string()))
+                                .as_str()
+                                .to_string(),
+                        );
+                    }
+
+                    for blob_item in blob.blobs.items {
+                        match blob_item {
+                            BlobItem::Blob(b) => {
+                                result.contents.push(Content {
+                                    key: replace_first(
+                                        b.name,
+                                        self.base_prefix.clone().trim_end_matches('/').to_string(),
+                                        format!("{}", self.repository_id),
+                                    ),
+                                    last_modified: b
+                                        .properties
+                                        .last_modified
+                                        .format(&Rfc3339)
+                                        .unwrap_or_else(|_| String::from("Invalid DateTime")),
+                                    etag: b.properties.etag.to_string(),
+                                    size: b.properties.content_length as i64,
+                                    storage_class: b.properties.blob_type.to_string(),
+                                });
+                            }
+                            BlobItem::BlobPrefix(bp) => {
+                                result.common_prefixes.push(CommonPrefix {
+                                    prefix: replace_first(
+                                        bp.name,
+                                        self.base_prefix.clone().trim_end_matches('/').to_string(),
+                                        format!("{}", self.repository_id),
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                Err(_) => (),
+            }
+        }
+
+        Ok(result)
+    }
 }

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -82,6 +82,13 @@ pub trait Repository {
         delimiter: Option<String>,
         max_keys: NonZeroU32,
     ) -> Result<ListBucketResult, Box<dyn APIError>>;
+    async fn list_buckets_accounts(
+        &self,
+        prefix: String,
+        continuation_token: Option<String>,
+        delimiter: Option<String>,
+        max_keys: NonZeroU32,
+    ) -> Result<ListBucketResult, Box<dyn APIError>>;
 }
 
 #[derive(Debug, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ async fn list_objects(
 
     let (repository_id, prefix) = split_at_first_slash(&path_prefix);
 
-    let mut max_keys = NonZeroU32::new(20).unwrap_or(NonZeroU32::new(20).unwrap());
+    let mut max_keys = NonZeroU32::new(1000).unwrap();
     if let Some(mk) = info.max_keys {
         max_keys = mk;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -572,6 +572,40 @@ async fn list_objects(
     }
 }
 
+#[get("/list_accounts")]
+async fn list_accounts(api_client: web::Data<SourceAPI>) -> impl Responder {
+    // TODO: Change to some existing default accId & repoId
+    let account_id = String::from("adarsh");
+    let repository_id = String::from("adarsh-dev");
+
+    if let Ok(client) = api_client
+        .get_backend_client(&account_id, &repository_id.to_string())
+        .await
+    {
+        match client
+            // Pass default static values
+            .list_buckets_accounts(
+                "".to_string(),
+                None,
+                Some("/".to_string()),
+                NonZeroU32::new(1000).unwrap(),
+            )
+            .await
+        {
+            Ok(res) => match to_string_with_root("ListBucketResult", &res) {
+                Ok(serialized) => HttpResponse::Ok()
+                    .content_type("application/xml")
+                    .body(serialized),
+                Err(e) => HttpResponse::InternalServerError().finish(),
+            },
+            Err(_) => HttpResponse::NotFound().finish(),
+        }
+    } else {
+        // Could not find the repository
+        return HttpResponse::NotFound().finish();
+    }
+}
+
 #[get("/")]
 async fn index() -> impl Responder {
     HttpResponse::Ok().body(format!("Source Cooperative Data Proxy v{}", VERSION))
@@ -609,6 +643,7 @@ async fn main() -> std::io::Result<()> {
             .service(post_handler)
             .service(put_object)
             .service(head_object)
+            .service(list_accounts)
             .service(list_objects)
             .service(index)
     })


### PR DESCRIPTION
**Related Issue(s):** #
[#16](https://github.com/source-cooperative/data.source.coop/issues/16)

**Proposed Changes:**

1. Added get api endpoint list_accounts to return all accounts in bucket

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [x] This PR has **no** breaking changes.
- [ ] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] All tests are passing.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
