### PR TITLE
Observability/convert error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,7 +2353,6 @@ dependencies = [
  "rusoto_s3",
  "serde",
  "serde-xml-rs",
- "serde_json",
  "sha2 0.10.8",
  "thiserror 2.0.12",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ xml-rs = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde-xml-rs = "0.6"
 bytes = "1.0"
-serde_json = "1.0"
 pin-project-lite = "0.2"
 futures = "0.3"
 futures-core = "0.3"

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -27,5 +27,5 @@ pub trait API {
         &self,
         account_id: String,
         user_identity: UserIdentity,
-    ) -> Result<Account, ()>;
+    ) -> Result<Account, BackendError>;
 }

--- a/src/apis/source.rs
+++ b/src/apis/source.rs
@@ -405,20 +405,18 @@ impl SourceAPI {
 
         // If not in cache, fetch it
         let secret = self.fetch_api_key(access_key_id).await?;
+        
         // Cache the successful result
-        match secret {
-            Some(secret) => {
-                self.api_key_cache.insert(cache_key, secret.clone()).await;
-                Ok(secret)
-            }
-            None => {
-                let secret = APIKey {
-                    access_key_id: "".to_string(),
-                    secret_access_key: "".to_string(),
-                };
-                self.api_key_cache.insert(cache_key, secret.clone()).await;
-                Ok(secret)
-            }
+        if let Some(secret) = secret {
+            self.api_key_cache.insert(cache_key, secret.clone()).await;
+            Ok(secret)
+        } else {
+            let secret = APIKey {
+                access_key_id: "".to_string(),
+                secret_access_key: "".to_string(),
+            };
+            self.api_key_cache.insert(cache_key, secret.clone()).await;
+            Ok(secret)
         }
     }
 

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -1,4 +1,3 @@
-use crate::utils::errors::APIError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use core::num::NonZeroU32;
@@ -9,6 +8,7 @@ use std::pin::Pin;
 
 use reqwest::Error as ReqwestError;
 type BoxedReqwestStream = Pin<Box<dyn Stream<Item = Result<Bytes, ReqwestError>> + Send>>;
+use crate::utils::errors::BackendError;
 
 pub struct GetObjectResponse {
     pub content_length: u64,
@@ -39,55 +39,55 @@ pub struct CompleteMultipartUploadResponse {
 
 #[async_trait]
 pub trait Repository {
-    async fn delete_object(&self, key: String) -> Result<(), Box<dyn APIError>>;
+    async fn delete_object(&self, key: String) -> Result<(), BackendError>;
     async fn create_multipart_upload(
         &self,
         key: String,
         content_type: Option<String>,
-    ) -> Result<CreateMultipartUploadResponse, Box<dyn APIError>>;
+    ) -> Result<CreateMultipartUploadResponse, BackendError>;
     async fn abort_multipart_upload(
         &self,
         key: String,
         upload_id: String,
-    ) -> Result<(), Box<dyn APIError>>;
+    ) -> Result<(), BackendError>;
     async fn complete_multipart_upload(
         &self,
         key: String,
         upload_id: String,
         parts: Vec<MultipartPart>,
-    ) -> Result<CompleteMultipartUploadResponse, Box<dyn APIError>>;
+    ) -> Result<CompleteMultipartUploadResponse, BackendError>;
     async fn upload_multipart_part(
         &self,
         key: String,
         upload_id: String,
         part_number: String,
         bytes: Bytes,
-    ) -> Result<UploadPartResponse, Box<dyn APIError>>;
+    ) -> Result<UploadPartResponse, BackendError>;
     async fn put_object(
         &self,
         key: String,
         bytes: Bytes,
         content_type: Option<String>,
-    ) -> Result<(), Box<dyn APIError>>;
+    ) -> Result<(), BackendError>;
     async fn get_object(
         &self,
         key: String,
         range: Option<String>,
-    ) -> Result<GetObjectResponse, Box<dyn APIError>>;
-    async fn head_object(&self, key: String) -> Result<HeadObjectResponse, Box<dyn APIError>>;
+    ) -> Result<GetObjectResponse, BackendError>;
+    async fn head_object(&self, key: String) -> Result<HeadObjectResponse, BackendError>;
     async fn list_objects_v2(
         &self,
         prefix: String,
         continuation_token: Option<String>,
         delimiter: Option<String>,
         max_keys: NonZeroU32,
-    ) -> Result<ListBucketResult, Box<dyn APIError>>;
+    ) -> Result<ListBucketResult, BackendError>;
     async fn copy_object(
         &self,
         copy_identifier_path: String,
         key: String,
         range: Option<String>,
-    ) -> Result<(), Box<dyn APIError>>;
+    ) -> Result<(), BackendError>;
 }
 
 #[derive(Debug, Serialize)]

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1,9 +1,10 @@
+use super::common::{MultipartPart, UploadPartResponse};
 use crate::backends::common::{
     CommonPrefix, CompleteMultipartUploadResponse, Content, CreateMultipartUploadResponse,
     GetObjectResponse, HeadObjectResponse, ListBucketResult, Repository,
 };
 use crate::utils::core::replace_first;
-use crate::utils::errors::{APIError, InternalServerError, ObjectNotFoundError};
+use crate::utils::errors::BackendError;
 use actix_web::http::header::RANGE;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -12,15 +13,12 @@ use core::num::NonZeroU32;
 use futures_core::Stream;
 use reqwest;
 use rusoto_core::Region;
-use rusoto_core::RusotoError;
 use rusoto_s3::{
     AbortMultipartUploadRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
     CompletedPart, CreateMultipartUploadRequest, DeleteObjectRequest, HeadObjectRequest,
     ListObjectsV2Request, PutObjectRequest, S3Client, UploadPartRequest, S3,
 };
 use std::pin::Pin;
-
-use super::common::{MultipartPart, UploadPartResponse};
 
 pub struct S3Repository {
     pub account_id: String,
@@ -33,81 +31,89 @@ pub struct S3Repository {
     pub secret_access_key: Option<String>,
 }
 
+impl S3Repository {
+    fn create_client(&self) -> Result<S3Client, BackendError> {
+        if self.auth_method == "s3_access_key" {
+            let credentials = rusoto_credential::StaticProvider::new_minimal(
+                self.access_key_id.clone().unwrap(),
+                self.secret_access_key.clone().unwrap(),
+            );
+            return Ok(S3Client::new_with(
+                rusoto_core::request::HttpClient::new().unwrap(),
+                credentials,
+                self.region.clone(),
+            ));
+        } else if self.auth_method == "s3_ecs_task_role" {
+            let credentials = rusoto_credential::ContainerProvider::new();
+            return Ok(S3Client::new_with(
+                rusoto_core::request::HttpClient::new().unwrap(),
+                credentials,
+                self.region.clone(),
+            ));
+        } else if self.auth_method == "s3_local" {
+            let credentials = rusoto_credential::ChainProvider::new();
+            return Ok(S3Client::new_with(
+                rusoto_core::request::HttpClient::new().unwrap(),
+                credentials,
+                self.region.clone(),
+            ));
+        } else {
+            return Err(BackendError::UnsupportedAuthMethod(format!(
+                "Unsupported auth method: {}",
+                self.auth_method
+            )));
+        }
+    }
+}
+
 #[async_trait]
 impl Repository for S3Repository {
     async fn get_object(
         &self,
         key: String,
         range: Option<String>,
-    ) -> Result<GetObjectResponse, Box<dyn APIError>> {
-        match self.head_object(key.clone()).await {
-            Ok(head_object_response) => {
-                let client = reqwest::Client::new();
-                let url: String;
+    ) -> Result<GetObjectResponse, BackendError> {
+        let head_object_response = self.head_object(key.clone()).await?;
+        let client = reqwest::Client::new();
+        let url: String;
 
-                if self.auth_method == "s3_local" {
-                    url = format!(
-                        "http://localhost:5050/{}/{}/{}",
-                        self.bucket, self.base_prefix, key
-                    )
-                } else {
-                    url = format!(
-                        "https://s3.{}.amazonaws.com/{}/{}/{}",
-                        self.region.name(),
-                        self.bucket,
-                        self.base_prefix,
-                        key
-                    );
-                }
-                // Start building the request
-                let mut request = client.get(url);
-
-                // If a range is provided, add it to the headers
-                if let Some(range_value) = range {
-                    request = request.header(RANGE, range_value);
-                }
-
-                // Send the request and await the response
-                match request.send().await {
-                    Ok(response) => {
-                        // Get the byte stream from the response
-                        let content_length = response.content_length();
-                        let stream = response.bytes_stream();
-                        let boxed_stream: Pin<
-                            Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>,
-                        > = Box::pin(stream);
-
-                        Ok(GetObjectResponse {
-                            content_length: content_length.unwrap_or(0) as u64,
-                            content_type: head_object_response.content_type,
-                            etag: head_object_response.etag,
-                            last_modified: head_object_response.last_modified,
-                            body: boxed_stream,
-                        })
-                    }
-                    Err(error) => {
-                        if error.is_status() {
-                            let code = error.status().unwrap().as_u16();
-                            if code == 404 {
-                                return Err(Box::new(ObjectNotFoundError {
-                                    account_id: self.account_id.clone(),
-                                    repository_id: self.repository_id.clone(),
-                                    key,
-                                }));
-                            }
-                        }
-
-                        return Err(Box::new(InternalServerError {
-                            message: "Internal Server Error".to_string(),
-                        }));
-                    }
-                }
-            }
-            Err(err) => {
-                // Pass through the error from the head_object call
-                return Err(err);
-            }
+        if self.auth_method == "s3_local" {
+            url = format!(
+                "http://localhost:5050/{}/{}/{}",
+                self.bucket, self.base_prefix, key
+            )
+        } else {
+            url = format!(
+                "https://s3.{}.amazonaws.com/{}/{}/{}",
+                self.region.name(),
+                self.bucket,
+                self.base_prefix,
+                key
+            );
         }
+        // Start building the request
+        let mut request = client.get(url);
+
+        // If a range is provided, add it to the headers
+        if let Some(range_value) = range {
+            request = request.header(RANGE, range_value);
+        }
+
+        // Send the request and await the response
+        let response = request.send().await?;
+        // Get the byte stream from the response
+        let content_length = response.content_length();
+        let stream = response.bytes_stream();
+        let boxed_stream: Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>> =
+            Box::pin(stream);
+
+        Ok(GetObjectResponse {
+            content_length: content_length.unwrap_or(0) as u64,
+            content_type: head_object_response.content_type,
+            etag: head_object_response.etag,
+            last_modified: head_object_response.last_modified,
+            body: boxed_stream,
+        })
     }
 
     async fn put_object(
@@ -115,38 +121,8 @@ impl Repository for S3Repository {
         key: String,
         bytes: Bytes,
         content_type: Option<String>,
-    ) -> Result<(), Box<dyn APIError>> {
-        let client: S3Client;
-
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
+    ) -> Result<(), BackendError> {
+        let client = self.create_client()?;
 
         let request = PutObjectRequest {
             bucket: self.bucket.clone(),
@@ -156,50 +132,16 @@ impl Repository for S3Repository {
             ..Default::default()
         };
 
-        match client.put_object(request).await {
-            Ok(_) => Ok(()),
-            Err(e) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        client.put_object(request).await?;
+        Ok(())
     }
 
     async fn create_multipart_upload(
         &self,
         key: String,
         content_type: Option<String>,
-    ) -> Result<CreateMultipartUploadResponse, Box<dyn APIError>> {
-        let client: S3Client;
-
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
+    ) -> Result<CreateMultipartUploadResponse, BackendError> {
+        let client = self.create_client()?;
 
         let request = CreateMultipartUploadRequest {
             bucket: self.bucket.clone(),
@@ -208,54 +150,20 @@ impl Repository for S3Repository {
             ..Default::default()
         };
 
-        match client.create_multipart_upload(request).await {
-            Ok(result) => Ok(CreateMultipartUploadResponse {
-                bucket: self.account_id.clone(),
-                key: key.clone(),
-                upload_id: result.upload_id.unwrap(),
-            }),
-            Err(e) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        let result = client.create_multipart_upload(request).await?;
+        Ok(CreateMultipartUploadResponse {
+            bucket: self.account_id.clone(),
+            key: key.clone(),
+            upload_id: result.upload_id.unwrap(),
+        })
     }
 
     async fn abort_multipart_upload(
         &self,
         key: String,
         upload_id: String,
-    ) -> Result<(), Box<dyn APIError>> {
-        let client: S3Client;
-
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
+    ) -> Result<(), BackendError> {
+        let client = self.create_client()?;
 
         let request = AbortMultipartUploadRequest {
             bucket: self.bucket.clone(),
@@ -264,12 +172,8 @@ impl Repository for S3Repository {
             ..Default::default()
         };
 
-        match client.abort_multipart_upload(request).await {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        client.abort_multipart_upload(request).await?;
+        Ok(())
     }
 
     async fn complete_multipart_upload(
@@ -277,38 +181,8 @@ impl Repository for S3Repository {
         key: String,
         upload_id: String,
         parts: Vec<MultipartPart>,
-    ) -> Result<CompleteMultipartUploadResponse, Box<dyn APIError>> {
-        let client: S3Client;
-
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
+    ) -> Result<CompleteMultipartUploadResponse, BackendError> {
+        let client = self.create_client()?;
 
         let request = CompleteMultipartUploadRequest {
             bucket: self.bucket.clone(),
@@ -328,17 +202,13 @@ impl Repository for S3Repository {
             ..Default::default()
         };
 
-        match client.complete_multipart_upload(request).await {
-            Ok(result) => Ok(CompleteMultipartUploadResponse {
-                location: "".to_string(),
-                bucket: self.account_id.clone(),
-                key: key.clone(),
-                etag: result.e_tag.unwrap(),
-            }),
-            Err(e) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        let result = client.complete_multipart_upload(request).await?;
+        Ok(CompleteMultipartUploadResponse {
+            location: "".to_string(),
+            bucket: self.account_id.clone(),
+            key: key.clone(),
+            etag: result.e_tag.unwrap(),
+        })
     }
 
     async fn upload_multipart_part(
@@ -347,38 +217,8 @@ impl Repository for S3Repository {
         upload_id: String,
         part_number: String,
         bytes: Bytes,
-    ) -> Result<UploadPartResponse, Box<dyn APIError>> {
-        let client: S3Client;
-
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
+    ) -> Result<UploadPartResponse, BackendError> {
+        let client = self.create_client()?;
 
         let request = UploadPartRequest {
             bucket: self.bucket.clone(),
@@ -389,128 +229,44 @@ impl Repository for S3Repository {
             ..Default::default()
         };
 
-        match client.upload_part(request).await {
-            Ok(result) => Ok(UploadPartResponse {
-                etag: result.e_tag.unwrap(),
-            }),
-            Err(_) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        let result = client.upload_part(request).await?;
+        Ok(UploadPartResponse {
+            etag: result.e_tag.unwrap(),
+        })
     }
 
-    async fn delete_object(&self, key: String) -> Result<(), Box<dyn APIError>> {
-        let client: S3Client;
+    async fn delete_object(&self, key: String) -> Result<(), BackendError> {
+        let client = self.create_client()?;
 
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
         let request = DeleteObjectRequest {
             bucket: self.bucket.clone(),
             key: format!("{}/{}", self.base_prefix, key),
             ..Default::default()
         };
 
-        match client.delete_object(request).await {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            })),
-        }
+        client.delete_object(request).await?;
+        Ok(())
     }
 
-    async fn head_object(&self, key: String) -> Result<HeadObjectResponse, Box<dyn APIError>> {
-        let client: S3Client;
+    async fn head_object(&self, key: String) -> Result<HeadObjectResponse, BackendError> {
+        let client = self.create_client()?;
 
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
         let request = HeadObjectRequest {
             bucket: self.bucket.clone(),
             key: format!("{}/{}", self.base_prefix, key),
             ..Default::default()
         };
 
-        match client.head_object(request).await {
-            Ok(result) => Ok(HeadObjectResponse {
-                content_length: result.content_length.unwrap_or(0) as u64,
-                content_type: result.content_type.unwrap_or_else(|| "".to_string()),
-                etag: result.e_tag.unwrap_or_else(|| "".to_string()),
-                last_modified: result
-                    .last_modified
-                    .unwrap_or_else(|| Utc::now().to_rfc2822()),
-            }),
-            Err(error) => {
-                match error {
-                    RusotoError::Unknown(response) => {
-                        if response.status.eq(&404) {
-                            return Err(Box::new(ObjectNotFoundError {
-                                account_id: self.account_id.clone(),
-                                repository_id: self.repository_id.clone(),
-                                key,
-                            }));
-                        }
-                    }
-                    _ => (),
-                }
+        let result = client.head_object(request).await?;
 
-                Err(Box::new(InternalServerError {
-                    message: format!("Internal Server Error"),
-                }))
-            }
-        }
+        Ok(HeadObjectResponse {
+            content_length: result.content_length.unwrap_or(0) as u64,
+            content_type: result.content_type.unwrap_or_else(|| "".to_string()),
+            etag: result.e_tag.unwrap_or_else(|| "".to_string()),
+            last_modified: result
+                .last_modified
+                .unwrap_or_else(|| Utc::now().to_rfc2822()),
+        })
     }
 
     async fn list_objects_v2(
@@ -519,38 +275,9 @@ impl Repository for S3Repository {
         continuation_token: Option<String>,
         delimiter: Option<String>,
         max_keys: NonZeroU32,
-    ) -> Result<ListBucketResult, Box<dyn APIError>> {
-        let client: S3Client;
+    ) -> Result<ListBucketResult, BackendError> {
+        let client = self.create_client()?;
 
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
         let mut request = ListObjectsV2Request {
             bucket: self.bucket.clone(),
             prefix: Some(format!("{}/{}", self.base_prefix, prefix)),
@@ -563,180 +290,95 @@ impl Repository for S3Repository {
             request.continuation_token = Some(token);
         }
 
-        match client.list_objects_v2(request).await {
-            Ok(output) => {
-                let result = ListBucketResult {
-                    name: format!("{}", self.account_id),
-                    prefix: format!("{}/{}", self.repository_id, prefix),
-                    key_count: output.key_count.unwrap_or(0),
-                    max_keys: output.max_keys.unwrap_or(0),
-                    is_truncated: output.is_truncated.unwrap_or(false),
-                    next_continuation_token: output.next_continuation_token,
-                    contents: output
-                        .contents
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|item| Content {
-                            key: replace_first(
-                                item.key.clone().unwrap_or_else(|| "".to_string()),
-                                self.base_prefix.clone(),
-                                format!("{}", self.repository_id),
-                            ),
-                            last_modified: item
-                                .last_modified
-                                .clone()
-                                .unwrap_or_else(|| Utc::now().to_rfc2822()),
-                            etag: item.e_tag.clone().unwrap_or_else(|| "".to_string()),
-                            size: item.size.unwrap_or(0),
-                            storage_class: item
-                                .storage_class
-                                .clone()
-                                .unwrap_or_else(|| "".to_string()),
-                        })
-                        .collect(),
-                    common_prefixes: output
-                        .common_prefixes
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|item| CommonPrefix {
-                            prefix: replace_first(
-                                item.prefix.clone().unwrap_or_else(|| "".to_string()),
-                                self.base_prefix.clone(),
-                                format!("{}", self.repository_id),
-                            ),
-                        })
-                        .collect(),
-                };
+        let output = client.list_objects_v2(request).await?;
+        let result = ListBucketResult {
+            name: format!("{}", self.account_id),
+            prefix: format!("{}/{}", self.repository_id, prefix),
+            key_count: output.key_count.unwrap_or(0),
+            max_keys: output.max_keys.unwrap_or(0),
+            is_truncated: output.is_truncated.unwrap_or(false),
+            next_continuation_token: output.next_continuation_token,
+            contents: output
+                .contents
+                .unwrap_or_default()
+                .iter()
+                .map(|item| Content {
+                    key: replace_first(
+                        item.key.clone().unwrap_or_else(|| "".to_string()),
+                        self.base_prefix.clone(),
+                        format!("{}", self.repository_id),
+                    ),
+                    last_modified: item
+                        .last_modified
+                        .clone()
+                        .unwrap_or_else(|| Utc::now().to_rfc2822()),
+                    etag: item.e_tag.clone().unwrap_or_else(|| "".to_string()),
+                    size: item.size.unwrap_or(0),
+                    storage_class: item.storage_class.clone().unwrap_or_else(|| "".to_string()),
+                })
+                .collect(),
+            common_prefixes: output
+                .common_prefixes
+                .unwrap_or_default()
+                .iter()
+                .map(|item| CommonPrefix {
+                    prefix: replace_first(
+                        item.prefix.clone().unwrap_or_else(|| "".to_string()),
+                        self.base_prefix.clone(),
+                        format!("{}", self.repository_id),
+                    ),
+                })
+                .collect(),
+        };
 
-                return Ok(result);
-            }
-            Err(error) => {
-                return Err(Box::new(InternalServerError {
-                    message: "Internal Server Error".to_string(),
-                }));
-            }
-        }
+        Ok(result)
     }
+
     async fn copy_object(
         &self,
         copy_identifier_path: String,
         key: String,
         range: Option<String>,
-    ) -> Result<(), Box<dyn APIError>> {
-        let client: S3Client;
+    ) -> Result<(), BackendError> {
+        let client = self.create_client()?;
 
-        if self.auth_method == "s3_access_key" {
-            let credentials = rusoto_credential::StaticProvider::new_minimal(
-                self.access_key_id.clone().unwrap(),
-                self.secret_access_key.clone().unwrap(),
-            );
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_ecs_task_role" {
-            let credentials = rusoto_credential::ContainerProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else if self.auth_method == "s3_local" {
-            let credentials = rusoto_credential::ChainProvider::new();
-            client = S3Client::new_with(
-                rusoto_core::request::HttpClient::new().unwrap(),
-                credentials,
-                self.region.clone(),
-            );
-        } else {
-            return Err(Box::new(InternalServerError {
-                message: format!("Internal Server Error"),
-            }));
-        }
         let request = HeadObjectRequest {
             bucket: self.bucket.clone(),
             key: format!("{}", copy_identifier_path),
             ..Default::default()
         };
 
-        match client.head_object(request).await {
-            Ok(result) => {
-                let url_client = reqwest::Client::new();
-                let url: String;
+        let result = client.head_object(request).await?;
+        let url_client = reqwest::Client::new();
+        let url: String;
 
-                if self.auth_method == "s3_local" {
-                    url = format!(
-                        "http://localhost:5050/{}/{}",
-                        self.bucket, copy_identifier_path
-                    )
-                } else {
-                    url = format!(
-                        "https://s3.{}.amazonaws.com/{}/{}",
-                        self.region.name(),
-                        self.bucket,
-                        copy_identifier_path
-                    );
-                }
-
-                let mut request = url_client.get(url);
-
-                if let Some(range_value) = range {
-                    request = request.header(RANGE, range_value);
-                }
-
-                match request.send().await {
-                    Ok(response) => {
-                        let content_bytes = response
-                            .bytes()
-                            .await
-                            .unwrap_or_else(|_| bytes::Bytes::from(vec![]));
-                        match self
-                            .put_object(key.clone(), content_bytes, result.content_type)
-                            .await
-                        {
-                            Ok(_put_res) => Ok(()),
-                            Err(err) => {
-                                return Err(err);
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        if error.is_status() {
-                            let code = error.status().unwrap().as_u16();
-                            if code == 404 {
-                                return Err(Box::new(ObjectNotFoundError {
-                                    account_id: self.account_id.clone(),
-                                    repository_id: self.repository_id.clone(),
-                                    key,
-                                }));
-                            }
-                        }
-
-                        return Err(Box::new(InternalServerError {
-                            message: "Internal Server Error".to_string(),
-                        }));
-                    }
-                }
-            }
-            Err(error) => {
-                match error {
-                    RusotoError::Unknown(response) => {
-                        if response.status.eq(&404) {
-                            return Err(Box::new(ObjectNotFoundError {
-                                account_id: self.account_id.clone(),
-                                repository_id: self.repository_id.clone(),
-                                key,
-                            }));
-                        }
-                    }
-                    _ => (),
-                }
-
-                Err(Box::new(InternalServerError {
-                    message: format!("Internal Server Error"),
-                }))
-            }
+        if self.auth_method == "s3_local" {
+            url = format!(
+                "http://localhost:5050/{}/{}",
+                self.bucket, copy_identifier_path
+            )
+        } else {
+            url = format!(
+                "https://s3.{}.amazonaws.com/{}/{}",
+                self.region.name(),
+                self.bucket,
+                copy_identifier_path
+            );
         }
+
+        let mut request = url_client.get(url);
+
+        if let Some(range_value) = range {
+            request = request.header(RANGE, range_value);
+        }
+
+        let response = request.send().await?;
+        let content_bytes = response
+            .bytes()
+            .await
+            .unwrap_or_else(|_| bytes::Bytes::from(vec![]));
+        self.put_object(key.clone(), content_bytes, result.content_type)
+            .await?;
+        Ok(())
     }
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -1,45 +1,68 @@
 use actix_web::error;
 use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
+use azure_core::error::Error as AzureError;
 use log::error;
+use quick_xml::DeError;
 use reqwest::Error as ReqwestError;
-use serde::Serialize;
-use std::error::Error;
-use std::fmt;
+use rusoto_core::RusotoError;
+use rusoto_s3::{
+    AbortMultipartUploadError, CompleteMultipartUploadError, CreateMultipartUploadError,
+    DeleteObjectError, HeadObjectError, ListObjectsV2Error, PutObjectError, UploadPartError,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum BackendError {
     #[error("repository not found")]
     RepositoryNotFound,
+
     #[error("failed to fetch repository permissions")]
     RepositoryPermissionsNotFound,
+
     #[error("source repository missing primary mirror")]
     SourceRepositoryMissingPrimaryMirror,
+
     #[error("data connection not found")]
     DataConnectionNotFound,
+
     #[error("reqwest error (url {}, message {})", .0.url().map(|u| u.to_string()).unwrap_or("unknown".to_string()), .0.to_string())]
     ReqwestError(#[from] ReqwestError),
-    #[error("Api threw a server error (url {}, status {}, message {})", .url, .status, .message)]
+
+    #[error("api threw a server error (url {}, status {}, message {})", .url, .status, .message)]
     ApiServerError {
         url: String,
         status: u16,
         message: String,
     },
-    #[error("Api threw a client error (url {}, status {}, message {})", .url, .status, .message)]
+
+    #[error("api threw a client error (url {}, status {}, message {})", .url, .status, .message)]
     ApiClientError {
         url: String,
         status: u16,
         message: String,
     },
-    #[error("Failed to parse JSON (url {})", .url)]
+
+    #[error("failed to parse JSON (url {})", .url)]
     JsonParseError { url: String },
-    #[error("Unexpected data connection provider (provider {})", .provider)]
+
+    #[error("unexpected data connection provider (provider {})", .provider)]
     UnexpectedDataConnectionProvider { provider: String },
-    #[error("Unauthorized")]
-    UnauthorizationError,
-    #[error("Unexpected API error: {0}")] // TODO: remove this
+
+    #[error("unauthorized")]
+    UnauthorizedError,
+
+    #[error("unexpected API error: {0}")] // TODO: remove this
     UnexpectedApiError(String),
+
+    #[error("unsupported auth method: {0}")]
+    UnsupportedAuthMethod(String),
+
+    #[error("unsupported operation: {0}")]
+    UnsupportedOperation(String),
+
+    #[error("xml parse error: {0}")]
+    XmlParseError(String),
 }
 
 impl error::ResponseError for BackendError {
@@ -57,8 +80,11 @@ impl error::ResponseError for BackendError {
                 HttpResponse::InternalServerError().finish()
             }
             BackendError::RepositoryPermissionsNotFound => HttpResponse::BadGateway().finish(),
-            BackendError::UnauthorizationError => HttpResponse::Unauthorized().finish(),
+            BackendError::UnauthorizedError => HttpResponse::Unauthorized().finish(),
             BackendError::UnexpectedApiError(_) => HttpResponse::InternalServerError().finish(),
+            BackendError::UnsupportedAuthMethod(_) => HttpResponse::BadRequest().finish(),
+            BackendError::UnsupportedOperation(_) => HttpResponse::BadRequest().finish(),
+            BackendError::XmlParseError(_) => HttpResponse::InternalServerError().finish(),
         }
     }
 
@@ -75,58 +101,66 @@ impl error::ResponseError for BackendError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             BackendError::RepositoryPermissionsNotFound => StatusCode::BAD_GATEWAY,
-            BackendError::UnauthorizationError => StatusCode::UNAUTHORIZED,
+            BackendError::UnauthorizedError => StatusCode::UNAUTHORIZED,
             BackendError::UnexpectedApiError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            BackendError::UnsupportedAuthMethod(_) => StatusCode::BAD_REQUEST,
+            BackendError::UnsupportedOperation(_) => StatusCode::BAD_REQUEST,
+            BackendError::XmlParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
 
-impl From<Box<dyn APIError>> for BackendError {
-    fn from(error: Box<dyn APIError>) -> BackendError {
+// Azure API Errors
+impl From<AzureError> for BackendError {
+    fn from(error: AzureError) -> BackendError {
         BackendError::UnexpectedApiError(error.to_string())
     }
 }
 
-pub trait APIError: std::error::Error + Send + Sync {
-    fn to_response(&self) -> HttpResponse;
+// S3 API Errors
+impl From<RusotoError<HeadObjectError>> for BackendError {
+    fn from(error: RusotoError<HeadObjectError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
 }
-
-#[derive(Serialize, Debug)]
-pub struct ObjectNotFoundError {
-    pub account_id: String,
-    pub repository_id: String,
-    pub key: String,
+impl From<RusotoError<DeleteObjectError>> for BackendError {
+    fn from(error: RusotoError<DeleteObjectError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
 }
-
-impl APIError for ObjectNotFoundError {
-    fn to_response(&self) -> HttpResponse {
-        HttpResponse::NotFound().json(self)
+impl From<RusotoError<PutObjectError>> for BackendError {
+    fn from(error: RusotoError<PutObjectError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
+}
+impl From<RusotoError<CreateMultipartUploadError>> for BackendError {
+    fn from(error: RusotoError<CreateMultipartUploadError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
+}
+impl From<RusotoError<AbortMultipartUploadError>> for BackendError {
+    fn from(error: RusotoError<AbortMultipartUploadError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
+}
+impl From<RusotoError<CompleteMultipartUploadError>> for BackendError {
+    fn from(error: RusotoError<CompleteMultipartUploadError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
+}
+impl From<RusotoError<UploadPartError>> for BackendError {
+    fn from(error: RusotoError<UploadPartError>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
+    }
+}
+impl From<RusotoError<ListObjectsV2Error>> for BackendError {
+    fn from(error: RusotoError<ListObjectsV2Error>) -> BackendError {
+        BackendError::UnexpectedApiError(error.to_string())
     }
 }
 
-impl fmt::Display for ObjectNotFoundError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Object Not Found: {}", self.key)
+impl From<DeError> for BackendError {
+    fn from(error: DeError) -> BackendError {
+        BackendError::XmlParseError(format!("failed to parse xml: {}", error))
     }
 }
-
-impl Error for ObjectNotFoundError {}
-
-#[derive(Serialize, Debug)]
-pub struct InternalServerError {
-    pub message: String,
-}
-
-impl APIError for InternalServerError {
-    fn to_response(&self) -> HttpResponse {
-        HttpResponse::InternalServerError().json(self)
-    }
-}
-
-impl fmt::Display for InternalServerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Internal Server Error: {}", self.message)
-    }
-}
-
-impl Error for InternalServerError {}

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -23,6 +23,9 @@ pub enum BackendError {
     #[error("source repository missing primary mirror")]
     SourceRepositoryMissingPrimaryMirror,
 
+    #[error("api key not found")]
+    ApiKeyNotFound,
+
     #[error("data connection not found")]
     DataConnectionNotFound,
 
@@ -74,6 +77,7 @@ impl error::ResponseError for BackendError {
         match self {
             BackendError::RepositoryNotFound => HttpResponse::NotFound().finish(),
             BackendError::SourceRepositoryMissingPrimaryMirror => HttpResponse::NotFound().finish(),
+            BackendError::ApiKeyNotFound => HttpResponse::NotFound().finish(),
             BackendError::DataConnectionNotFound => HttpResponse::NotFound().finish(),
             BackendError::InvalidRequest(message) => {
                 HttpResponse::BadRequest().body(message.clone())
@@ -98,6 +102,7 @@ impl error::ResponseError for BackendError {
         match self {
             BackendError::RepositoryNotFound => StatusCode::NOT_FOUND,
             BackendError::SourceRepositoryMissingPrimaryMirror => StatusCode::NOT_FOUND,
+            BackendError::ApiKeyNotFound => StatusCode::NOT_FOUND,
             BackendError::DataConnectionNotFound => StatusCode::NOT_FOUND,
             BackendError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             BackendError::ReqwestError(_) => StatusCode::BAD_GATEWAY,


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

In #58, we introduced [`thiserror`](https://github.com/dtolnay/thiserror). When the API is overrun, we are now serving `500` rather than `404` responses (which seems more accurate to our needs) but our logs are missing important contextual information as they appear to be from the legacy `APIError` logs which lacked some information.  

This PR:

1. continues to convert the remainder of our codebase to make use of our new error/logging pattern
2. flattens out the `match` statements, as we can now throw our `BackendError` and have it automatically converted to a response via the `actix_web::error::ResponseError` trait, as demonstrated in the Actix guide: https://actix.rs/docs/errors#an-example-of-a-custom-error-response

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [ ] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] All tests are passing.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
