### PR TITLE
Add more clarity to cloud provider errors

### DIFF
--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -132,7 +132,10 @@ impl error::ResponseError for BackendError {
     }
 }
 
-fn get_rusoto_error_message<T: ToString>(operation: &str, error: RusotoError<T>) -> String {
+fn get_rusoto_error_message<T: std::error::Error>(
+    operation: &str,
+    error: RusotoError<T>,
+) -> String {
     match error {
         RusotoError::Service(error) => {
             format!("{} Service Error: {}", operation, error.to_string())

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -69,6 +69,12 @@ pub enum BackendError {
 
     #[error("xml parse error: {0}")]
     XmlParseError(String),
+
+    #[error(transparent)]
+    AzureError(#[from] AzureError),
+
+    #[error("s3 error: {0}")]
+    S3Error(String),
 }
 
 impl error::ResponseError for BackendError {
@@ -95,6 +101,8 @@ impl error::ResponseError for BackendError {
             BackendError::UnsupportedAuthMethod(_) => HttpResponse::BadRequest().finish(),
             BackendError::UnsupportedOperation(_) => HttpResponse::BadRequest().finish(),
             BackendError::XmlParseError(_) => HttpResponse::InternalServerError().finish(),
+            BackendError::AzureError(_) => HttpResponse::BadGateway().finish(),
+            BackendError::S3Error(_) => HttpResponse::BadGateway().finish(),
         }
     }
 
@@ -118,56 +126,80 @@ impl error::ResponseError for BackendError {
             BackendError::UnsupportedAuthMethod(_) => StatusCode::BAD_REQUEST,
             BackendError::UnsupportedOperation(_) => StatusCode::BAD_REQUEST,
             BackendError::XmlParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            BackendError::AzureError(_) => StatusCode::BAD_GATEWAY,
+            BackendError::S3Error(_) => StatusCode::BAD_GATEWAY,
         }
     }
 }
 
-// Azure API Errors
-impl From<AzureError> for BackendError {
-    fn from(error: AzureError) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+fn get_rusoto_error_message<T: ToString>(operation: &str, error: RusotoError<T>) -> String {
+    match error {
+        RusotoError::Service(error) => {
+            format!("{} Service Error: {}", operation, error.to_string())
+        }
+        RusotoError::HttpDispatch(error) => {
+            format!("{} HttpDispatch Error: {}", operation, error.to_string())
+        }
+        RusotoError::Credentials(error) => {
+            format!("{} Credentials Error: {}", operation, error.to_string())
+        }
+        RusotoError::Validation(error) => {
+            format!("{} Validation Error: {}", operation, error.to_string())
+        }
+        RusotoError::ParseError(error) => {
+            format!("{} Parse Error: {}", operation, error.to_string())
+        }
+        RusotoError::Unknown(error) => {
+            format!(
+                "{} Unknown Error: status {}, body {}",
+                operation,
+                error.status,
+                error.body_as_str(),
+            )
+        }
+        RusotoError::Blocking => format!("{} Blocking Error", operation,),
     }
 }
 
 // S3 API Errors
 impl From<RusotoError<HeadObjectError>> for BackendError {
     fn from(error: RusotoError<HeadObjectError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("HeadObject", error))
     }
 }
 impl From<RusotoError<DeleteObjectError>> for BackendError {
     fn from(error: RusotoError<DeleteObjectError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("DeleteObject", error))
     }
 }
 impl From<RusotoError<PutObjectError>> for BackendError {
     fn from(error: RusotoError<PutObjectError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("PutObject", error))
     }
 }
 impl From<RusotoError<CreateMultipartUploadError>> for BackendError {
     fn from(error: RusotoError<CreateMultipartUploadError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("CreateMultipartUpload", error))
     }
 }
 impl From<RusotoError<AbortMultipartUploadError>> for BackendError {
     fn from(error: RusotoError<AbortMultipartUploadError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("AbortMultipartUpload", error))
     }
 }
 impl From<RusotoError<CompleteMultipartUploadError>> for BackendError {
     fn from(error: RusotoError<CompleteMultipartUploadError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("CompleteMultipartUpload", error))
     }
 }
 impl From<RusotoError<UploadPartError>> for BackendError {
     fn from(error: RusotoError<UploadPartError>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("UploadPart", error))
     }
 }
 impl From<RusotoError<ListObjectsV2Error>> for BackendError {
     fn from(error: RusotoError<ListObjectsV2Error>) -> BackendError {
-        BackendError::UnexpectedApiError(error.to_string())
+        BackendError::S3Error(get_rusoto_error_message("ListObjectsV2", error))
     }
 }
 


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

Currently see a high number of error logs such as this:
```
Error: unexpected API error: expected value at line 1 column 1
```

Clearly a parse error, and being that it's an `UnexpectedApiError`, it's most likely coming from our translation from a `RusotoError`.  However, our translation reduced clarity, we don't know what operation we were attempting to perform when the error occurred or what type of `RusotoError` we received.

This PR attempts to increase that clarity by placing more details into the error string, also designating the error as an `S3Error`.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [ ] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] All tests are passing.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
