### PR TITLE
ci: run tests on every commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,5 @@
 - [ ] This PR has **no** breaking changes.
 - [ ] This PR contains only one commit.
 - [ ] I have updated or added new tests to cover the changes in this PR.
-- [ ] All tests are passing.
 - [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
       and I have opened issue/PR #XXX to track the change.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Set up Rust
+        uses: actions-rs/toolchain@8e603f32c5c6eeca5b1b2d9d1e7464d926082f1d # v1.0.0
+        with:
+          toolchain: stable
+      - name: Run tests
+        shell: bash
+        run: cargo test


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. I propose that rather than _asking_ that all tests are passing, we instead use GitHub's pr requirements that all checks pass. 

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [ ] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] All tests are passing.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.
