### PR TITLE
test: add tests for error translation to response codes

### DIFF
--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -228,7 +228,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::ObjectNotFound(key) => (),
+                BackendError::ObjectNotFound(_key) => (),
                 _ => panic!("expected error to be converted to ObjectNotFound"),
             }
             assert_eq!(
@@ -278,7 +278,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::S3Error(msg) => (),
+                BackendError::S3Error(_msg) => (),
                 _ => panic!("expected error to be converted to S3Error"),
             }
             assert_eq!(
@@ -311,7 +311,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::ObjectNotFound(key) => (),
+                BackendError::ObjectNotFound(_key) => (),
                 _ => panic!("expected error to be converted to ObjectNotFound"),
             }
             assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::XmlParseError(msg) => (),
+                BackendError::XmlParseError(_msg) => (),
                 _ => panic!("expected error to be converted to XmlParseError"),
             }
             assert_eq!(
@@ -473,7 +473,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::XmlParseError(msg) => (),
+                BackendError::XmlParseError(_msg) => (),
                 _ => panic!("expected error to be converted to XmlParseError"),
             }
             assert_eq!(

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -89,7 +89,7 @@ impl From<AzureError> for BackendError {
             AzureErrorKind::HttpResponse { status, error_code }
                 if *status == AzureStatusCode::NotFound =>
             {
-                BackendError::ObjectNotFound(error_code.as_ref().map(|s| s.to_string()))
+                BackendError::ObjectNotFound(error_code.clone())
             }
             _ => BackendError::AzureError(error),
         }
@@ -146,7 +146,12 @@ fn get_rusoto_error_message<T: std::error::Error>(
         RusotoError::Credentials(e) => format!("{} Credentials Error: {}", operation, e),
         RusotoError::Validation(e) => format!("{} Validation Error: {}", operation, e),
         RusotoError::ParseError(e) => format!("{} Parse Error: {}", operation, e),
-        RusotoError::Unknown(e) => format!("{} Unknown Error: status {}", operation, e.status),
+        RusotoError::Unknown(e) => format!(
+            "{} Unknown Error: status {}, body {}",
+            operation,
+            e.status,
+            e.body_as_str()
+        ),
         RusotoError::Blocking => format!("{} Blocking Error", operation),
     }
 }
@@ -294,7 +299,7 @@ mod tests {
             assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
             assert_eq!(
                 to_bytes(response.into_body()).await.unwrap(),
-                Bytes::from("Internal Server Error: s3 error: PutObject Unknown Error: status 500 Internal Server Error")
+                Bytes::from("Internal Server Error: s3 error: PutObject Unknown Error: status 500 Internal Server Error, body ")
             );
         }
     }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -227,10 +227,10 @@ mod tests {
             let error = RusotoError::Service(HeadObjectError::NoSuchKey("test-key".to_string()));
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::ObjectNotFound(_key) => (),
-                _ => panic!("expected error to be converted to ObjectNotFound"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::ObjectNotFound(_)),
+                "expected error to be ObjectNotFound"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::NOT_FOUND,
@@ -250,10 +250,10 @@ mod tests {
                 RusotoError::Service(ListObjectsV2Error::NoSuchBucket("test-bucket".to_string()));
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::RepositoryNotFound => (),
-                _ => panic!("expected error to be converted to RepositoryNotFound"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::RepositoryNotFound),
+                "expected error to be converted to RepositoryNotFound"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::NOT_FOUND,
@@ -277,10 +277,10 @@ mod tests {
                 });
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::S3Error(_msg) => (),
-                _ => panic!("expected error to be converted to S3Error"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::S3Error(_)),
+                "expected error to be converted to S3Error"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::BAD_GATEWAY,
@@ -310,10 +310,10 @@ mod tests {
             );
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::ObjectNotFound(_key) => (),
-                _ => panic!("expected error to be converted to ObjectNotFound"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::ObjectNotFound(_)),
+                "expected error to be converted to ObjectNotFound"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::NOT_FOUND,
@@ -338,10 +338,10 @@ mod tests {
             );
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::AzureError(_) => (),
-                _ => panic!("expected error to be converted to AzureError"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::AzureError(_)),
+                "expected error to be converted to AzureError"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::BAD_GATEWAY,
@@ -454,10 +454,10 @@ mod tests {
             let error = DeError::UnexpectedStart(b"unexpected start of stream".to_vec());
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::XmlParseError(_msg) => (),
-                _ => panic!("expected error to be converted to XmlParseError"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::XmlParseError(_)),
+                "expected error to be converted to XmlParseError"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -472,10 +472,10 @@ mod tests {
             };
             let backend_error = BackendError::from(error);
 
-            match &backend_error {
-                BackendError::XmlParseError(_msg) => (),
-                _ => panic!("expected error to be converted to XmlParseError"),
-            }
+            assert!(
+                matches!(backend_error, BackendError::XmlParseError(_)),
+                "expected error to be converted to XmlParseError"
+            );
             assert_eq!(
                 backend_error.status_code(),
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -27,7 +27,7 @@ pub enum BackendError {
     SourceRepositoryMissingPrimaryMirror,
 
     #[error("object not found: {0:?}")]
-    ObjectNotFound(Option<String>),
+    ObjectNotFound(String),
 
     #[error("api key not found")]
     ApiKeyNotFound,
@@ -89,7 +89,11 @@ impl From<AzureError> for BackendError {
             AzureErrorKind::HttpResponse { status, error_code }
                 if *status == AzureStatusCode::NotFound =>
             {
-                BackendError::ObjectNotFound(error_code.clone())
+                BackendError::ObjectNotFound(
+                    error_code
+                        .as_ref()
+                        .map_or("unknown".to_string(), |s| s.to_string()),
+                )
             }
             _ => BackendError::AzureError(error),
         }
@@ -146,12 +150,7 @@ fn get_rusoto_error_message<T: std::error::Error>(
         RusotoError::Credentials(e) => format!("{} Credentials Error: {}", operation, e),
         RusotoError::Validation(e) => format!("{} Validation Error: {}", operation, e),
         RusotoError::ParseError(e) => format!("{} Parse Error: {}", operation, e),
-        RusotoError::Unknown(e) => format!(
-            "{} Unknown Error: status {}, body {}",
-            operation,
-            e.status,
-            e.body_as_str()
-        ),
+        RusotoError::Unknown(e) => format!("{} Unknown Error: status {}", operation, e.status),
         RusotoError::Blocking => format!("{} Blocking Error", operation),
     }
 }
@@ -177,9 +176,7 @@ impl_s3_errors!(
 impl From<RusotoError<HeadObjectError>> for BackendError {
     fn from(error: RusotoError<HeadObjectError>) -> BackendError {
         match error {
-            RusotoError::Service(HeadObjectError::NoSuchKey(e)) => {
-                BackendError::ObjectNotFound(Some(e))
-            }
+            RusotoError::Service(HeadObjectError::NoSuchKey(e)) => BackendError::ObjectNotFound(e),
             _ => BackendError::S3Error(get_rusoto_error_message("HeadObject", error)),
         }
     }
@@ -203,5 +200,108 @@ impl From<DeError> for BackendError {
 impl From<serde_xml_rs::Error> for BackendError {
     fn from(error: serde_xml_rs::Error) -> BackendError {
         BackendError::XmlParseError(format!("failed to parse xml: {}", error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::error::ResponseError;
+    use actix_web::http::StatusCode;
+    use bytes::Bytes;
+    use rusoto_core::RusotoError;
+    use rusoto_s3::{HeadObjectError, ListObjectsV2Error, PutObjectError};
+
+    #[test]
+    fn test_head_object_error_conversion() {
+        // Test Rusoto HeadObject NoSuchKey error converts to 404
+        let error = RusotoError::Service(HeadObjectError::NoSuchKey("test-key".to_string()));
+        let backend_error = BackendError::from(error);
+        assert_eq!(backend_error.status_code(), StatusCode::NOT_FOUND);
+        assert_eq!(backend_error.to_string(), "object not found: \"test-key\"");
+    }
+
+    #[test]
+    fn test_list_objects_v2_error_conversion() {
+        // Test Rusoto ListObjectsV2 NoSuchBucket error converts to 404
+        let error =
+            RusotoError::Service(ListObjectsV2Error::NoSuchBucket("test-bucket".to_string()));
+        let backend_error = BackendError::from(error);
+        assert_eq!(backend_error.status_code(), StatusCode::NOT_FOUND);
+        assert_eq!(backend_error.to_string(), "repository not found");
+    }
+
+    #[test]
+    fn test_unauthorized_error() {
+        let error = BackendError::UnauthorizedError;
+        assert_eq!(error.status_code(), StatusCode::UNAUTHORIZED);
+        assert_eq!(error.to_string(), "unauthorized");
+    }
+
+    #[test]
+    fn test_invalid_request_error() {
+        let error = BackendError::InvalidRequest("bad input".to_string());
+        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(error.to_string(), "invalid request");
+    }
+
+    #[test]
+    fn test_unsupported_auth_method() {
+        let error = BackendError::UnsupportedAuthMethod("basic".to_string());
+        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(error.to_string(), "unsupported auth method: basic");
+    }
+
+    #[test]
+    fn test_unsupported_operation() {
+        let error = BackendError::UnsupportedOperation("delete".to_string());
+        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(error.to_string(), "unsupported operation: delete");
+    }
+
+    #[test]
+    fn test_s3_error_conversion() {
+        // Test S3 PutObject error converts to 502
+        let error: RusotoError<PutObjectError> =
+            RusotoError::Unknown(rusoto_core::request::BufferedHttpResponse {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                headers: Default::default(),
+                body: Bytes::new(),
+            });
+        let backend_error = BackendError::from(error);
+        assert_eq!(backend_error.status_code(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            backend_error.to_string(),
+            "s3 error: PutObject Unknown Error: status 500 Internal Server Error"
+        );
+    }
+
+    #[test]
+    fn test_azure_error_conversion() {
+        // Test Azure NotFound error converts to 404
+        let error = AzureError::new(
+            AzureErrorKind::HttpResponse {
+                status: AzureStatusCode::NotFound,
+                error_code: Some("ResourceNotFound".to_string()),
+            },
+            "Resource not found",
+        );
+        let backend_error = BackendError::from(error);
+        assert_eq!(backend_error.status_code(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            backend_error.to_string(),
+            "object not found: \"ResourceNotFound\""
+        );
+
+        // Test other Azure error converts to 502
+        let error = AzureError::new(
+            AzureErrorKind::HttpResponse {
+                status: AzureStatusCode::InternalServerError,
+                error_code: Some("InternalError".to_string()),
+            },
+            "Internal error",
+        );
+        let backend_error = BackendError::from(error);
+        assert_eq!(backend_error.status_code(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -13,7 +13,6 @@ use rusoto_s3::{
     AbortMultipartUploadError, CompleteMultipartUploadError, CreateMultipartUploadError,
     DeleteObjectError, HeadObjectError, ListObjectsV2Error, PutObjectError, UploadPartError,
 };
-use serde_xml_rs::Error as XmlError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -228,13 +228,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::ObjectNotFound(key) => {
-                    assert_eq!(
-                        key.as_deref(),
-                        Some("test-key"),
-                        "expected correct key in ObjectNotFound"
-                    )
-                }
+                BackendError::ObjectNotFound(key) => (),
                 _ => panic!("expected error to be converted to ObjectNotFound"),
             }
             assert_eq!(
@@ -284,10 +278,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::S3Error(msg) => assert!(
-                    msg.contains("PutObject Unknown Error"),
-                    "expected error message to contain PutObject Unknown Error"
-                ),
+                BackendError::S3Error(msg) => (),
                 _ => panic!("expected error to be converted to S3Error"),
             }
             assert_eq!(
@@ -320,11 +311,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::ObjectNotFound(key) => assert_eq!(
-                    key.as_deref(),
-                    Some("ResourceNotFound"),
-                    "expected correct key in ObjectNotFound"
-                ),
+                BackendError::ObjectNotFound(key) => (),
                 _ => panic!("expected error to be converted to ObjectNotFound"),
             }
             assert_eq!(
@@ -468,10 +455,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::XmlParseError(msg) => assert!(
-                    msg.contains("failed to parse xml"),
-                    "expected error message to mention XML parsing"
-                ),
+                BackendError::XmlParseError(msg) => (),
                 _ => panic!("expected error to be converted to XmlParseError"),
             }
             assert_eq!(
@@ -489,10 +473,7 @@ mod tests {
             let backend_error = BackendError::from(error);
 
             match &backend_error {
-                BackendError::XmlParseError(msg) => assert!(
-                    msg.contains("failed to parse xml"),
-                    "expected error message to mention XML parsing"
-                ),
+                BackendError::XmlParseError(msg) => (),
                 _ => panic!("expected error to be converted to XmlParseError"),
             }
             assert_eq!(


### PR DESCRIPTION
## What I'm changing

Add tests for how we translate error codes to response codes.

## How I did it

Buildout tests as separate modules within `errors`.

## How to test it

I think reviewing the tests and trusting the CI seems sufficient.

## PR Checklist

- [x] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->
