### PR TITLE
fix(logging): only log server errors, remove unnecessary details from logs

### DIFF
--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -26,7 +26,7 @@ pub enum BackendError {
     #[error("source repository missing primary mirror")]
     SourceRepositoryMissingPrimaryMirror,
 
-    #[error("object not found: {message}", message = .0.as_ref().unwrap_or(&"".to_string()))]
+    #[error("object not found: {}", .0.clone().unwrap_or_default())]
     ObjectNotFound(Option<String>),
 
     #[error("api key not found")]

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -149,12 +149,7 @@ fn get_rusoto_error_message<T: std::error::Error>(
         RusotoError::Credentials(e) => format!("{} Credentials Error: {}", operation, e),
         RusotoError::Validation(e) => format!("{} Validation Error: {}", operation, e),
         RusotoError::ParseError(e) => format!("{} Parse Error: {}", operation, e),
-        RusotoError::Unknown(e) => format!(
-            "{} Unknown Error: status {}, body {}",
-            operation,
-            e.status,
-            e.body_as_str()
-        ),
+        RusotoError::Unknown(e) => format!("{} Unknown Error: status {}", operation, e.status),
         RusotoError::Blocking => format!("{} Blocking Error", operation),
     }
 }
@@ -294,7 +289,7 @@ mod tests {
             assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
             assert_eq!(
                 to_bytes(response.into_body()).await.unwrap(),
-                Bytes::from("Internal Server Error: s3 error: PutObject Unknown Error: status 500 Internal Server Error, body ")
+                Bytes::from("Internal Server Error: s3 error: PutObject Unknown Error: status 500 Internal Server Error")
             );
         }
     }


### PR DESCRIPTION
## What I'm changing

1. We shouldn't log client errors (beyond the request logging middleware that we use)
2. ObjectNotFound errors should not log `Some(...)`
3. Don't log response bodies on upstream client request errors

## How I did it

See code...

## How to test it

See successful test output...

## PR Checklist

- [x] This PR has **no** breaking changes.
- [x] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->
