### PR TITLE
fix(errors): pass through client error status codes

### DIFF
--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -98,6 +98,11 @@ impl error::ResponseError for BackendError {
 
     fn status_code(&self) -> StatusCode {
         match self {
+            // Pass through client error status codes
+            BackendError::ApiClientError { status, .. } => {
+                StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_REQUEST)
+            }
+
             // 400
             BackendError::InvalidRequest(_)
             | BackendError::UnsupportedAuthMethod(_)
@@ -114,7 +119,6 @@ impl error::ResponseError for BackendError {
             // 502
             BackendError::ReqwestError(_)
             | BackendError::ApiServerError { .. }
-            | BackendError::ApiClientError { .. }
             | BackendError::RepositoryPermissionsNotFound
             | BackendError::AzureError(_)
             | BackendError::S3Error(_) => StatusCode::BAD_GATEWAY,

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -512,7 +512,7 @@ mod tests {
         }
 
         #[test]
-        fn should_handle_api_client_error() {
+        fn should_handle_api_client_error_400() {
             let error = BackendError::ApiClientError {
                 url: "https://api.example.com".to_string(),
                 status: 400,
@@ -520,8 +520,26 @@ mod tests {
             };
             assert_eq!(
                 error.status_code(),
-                StatusCode::BAD_GATEWAY,
-                "expected status code to be 502"
+                StatusCode::BAD_REQUEST,
+                "expected status code to be 400"
+            );
+            assert!(
+                error.to_string().contains("api threw a client error"),
+                "expected error message to mention client error"
+            );
+        }
+
+        #[test]
+        fn should_handle_api_client_error_404() {
+            let error = BackendError::ApiClientError {
+                url: "https://api.example.com".to_string(),
+                status: 404,
+                message: "Bad Request".to_string(),
+            };
+            assert_eq!(
+                error.status_code(),
+                StatusCode::NOT_FOUND,
+                "expected status code to be 404"
             );
             assert!(
                 error.to_string().contains("api threw a client error"),


### PR DESCRIPTION
## What I'm changing

I noticed that when an ApiClientError is thrown (e.g. the source API returns a `401` for a private repository), the proxy throws a `502` gateway error.  This obfuscates the underlying error.  Instead, we should pass that error through from the proxy.

<details>

<summary>Running into this error</summary>


I have a disabled repo at https://source.coop/alukach/test-repo. The API returns a `401` when I attempt to access it: https://source.coop/api/v1/repositories/alukach/test-repo
However, the data proxy currently returns a `502` because the `401`:

```sh
▶ curl https://data.source.coop/alukach/test-repo/xyz --verbose
// ...
< HTTP/2 502 
< date: Thu, 29 May 2025 19:42:09 GMT
< content-length: 203
< x-version: 0.1.28
< access-control-allow-credentials: true
< vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
< 
* Connection #0 to host data.source.coop left intact
Internal Server Error: api threw a client error (url https://source.coop/api/v1/repositories/alukach/test-repo, status 401, message {"code":401,"message":"You are not authorized to perform this action"})%       
```

</details>

## How I did it

Updated the ResponseError implementation for BackendError to correctly pass through client error status codes from ApiClientError, ensuring that the appropriate status code is returned in the response.

<!-- Discuss the implementation strategy and considerations made -->

## How to test it

## PR Checklist

- [x] This PR has **no** breaking changes.
- [x] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->
