### PR TITLE
fix: update source api types to match S2 codebase

### DIFF
--- a/src/apis/source.rs
+++ b/src/apis/source.rs
@@ -615,3 +615,86 @@ impl SourceApi {
         .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_json_parsing() {
+        let json_str = r#"
+        {
+          "updated_at": "2023-01-15T10:30:00.000Z",
+          "metadata": {
+            "primary_mirror": "aws-us-east-1",
+            "mirrors": {
+              "aws-us-east-1": {
+                "storage_type": "s3",
+                "is_primary": true,
+                "connection_id": "aws-connection-123",
+                "config": { "region": "us-east-1", "bucket": "example-bucket" },
+                "prefix": "example-account/sample-product/"
+              }
+            },
+            "tags": ["example", "test"],
+            "roles": {
+              "example-account": {
+                "granted_at": "2023-01-15T10:30:00.000Z",
+                "account_id": "example-account",
+                "role": "admin",
+                "granted_by": "example-account"
+              }
+            }
+          },
+          "created_at": "2023-01-01T00:00:00.000Z",
+          "disabled": false,
+          "visibility": "public",
+          "data_mode": "open",
+          "account_id": "example-account",
+          "description": "An example product for testing purposes.",
+          "product_id": "sample-product",
+          "featured": 0,
+          "title": "Sample Product",
+          "account": {
+            "identity_id": "12345678-1234-1234-1234-123456789abc",
+            "metadata_public": {
+              "domains": [
+                {
+                  "created_at": "2023-01-10T12:00:00.000Z",
+                  "domain": "example.com",
+                  "status": "unverified"
+                }
+              ],
+              "location": "Example City"
+            },
+            "updated_at": "2023-01-15T10:30:00.000Z",
+            "flags": ["create_repositories", "create_organizations"],
+            "created_at": "2023-01-01T00:00:00.000Z",
+            "emails": [
+              {
+                "verified": false,
+                "added_at": "2023-01-01T00:00:00.000Z",
+                "address": "user@example.com",
+                "is_primary": true
+              }
+            ],
+            "disabled": false,
+            "metadata_private": {},
+            "account_id": "example-account",
+            "name": "Example User",
+            "type": "individual"
+          }
+        }
+        "#;
+
+        match serde_json::from_str::<SourceProduct>(json_str) {
+            Ok(_product) => {
+                println!("✅ JSON parsed successfully!");
+            }
+            Err(e) => {
+                panic!("❌ JSON parsing failed: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What I'm changing

Currently, some buckets/prefixes return parse errors while others do not:

* ✅ https://data.source.coop/harvard-lil?list-type=1&prefix=gov-data
* ❌ https://data.source.coop/youssef-harby?list-type=1&prefix=weather-station-realtime-parquet
  ```
  Internal Server Error: failed to parse JSON (url https://source.coop/api/v1/products/youssef-harby/weather-station-realtime-parquet)
  ```

The core issue regarding why the second API response failed to parse is that the `youssef-harby` account contains a populated `metadata_public.domains` array:

```
▶ curl -s https://source.coop/api/v1/products/youssef-harby/weather-station-realtime-parquet | jq .account.metadata_public.domains
[
  {
    "created_at": "2025-09-27T20:25:04.246Z",
    "domain": "youssefharby.com",
    "status": "unverified"
  }
]
```

Note that the account used in the successful API response lacks a populated `metadata_public.domains` array:

```
▶ curl -s https://source.coop/api/v1/products/harvard-lil/gov-data | jq .account.metadata_public.domains                   
[]
```

The proxy fails when it encounters a populated domain array due to the fact that the domain struct in the data proxy codebase does not match the API response. On the API, the `status` value is an enum[^1] added in S2:

```ts
export const AccountDomainSchema = z.object({
  domain: z.string(),
  status: z.enum(["unverified", "pending", "verified"]),
  // ...
});
```

However, the data proxy is expecting the legacy schema where a domain would merely have a boolean `verified` property:

https://github.com/source-cooperative/data.source.coop/blob/f497d487c99ddffb2c376307c454460393866c71/src/apis/source.rs#L100-L104

## How I did it

In this PR, we update the expected API schema to match the schema from within the source.coop codebase, namely within the following files:

* https://github.com/source-cooperative/source.coop/blob/c49aa11bb3f7a7bfd7caa40ff66193f9fe437b08/src/types/product_v2.ts
* https://github.com/source-cooperative/source.coop/blob/c49aa11bb3f7a7bfd7caa40ff66193f9fe437b08/src/types/account.ts

I let Cursor AI take the wheel to update these types.

Also added tests with the real (but anonymized) data returned from https://source.coop/api/v1/products/youssef-harby/weather-station-realtime-parquet to ensure parsing would not throw an error.

Finally, improved the documentation of the file.

## How to test it

* See [ce22b16](https://github.com/source-cooperative/data.source.coop/pull/90/commits/ce22b165d9a6c9b7075d905f02bc415c24dfbc8a), note that tests fail
* See [c9a9bbc](https://github.com/source-cooperative/data.source.coop/pull/90/commits/c9a9bbcdf74f3defad3dd0ad040eb9e7450a1654), note that tests are now passing

## PR Checklist

- [ ] This PR has **no** breaking changes.
- [x] I have updated or added new tests to cover the changes in this PR.
- [x] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->


[^1]: https://github.com/source-cooperative/source.coop/blob/c49aa11bb3f7a7bfd7caa40ff66193f9fe437b08/src/types/account.ts#L52