### PR TITLE
fix: expose content-range header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,15 +123,17 @@ async fn get_object(
         .insert_header(("ETag", res.etag));
 
     if is_range_request {
-        response = response.insert_header((
-            "Content-Range",
-            format!(
-                "bytes {}-{}/{}",
-                range_start,
-                range_start + res.content_length - 1,
-                content_length
-            ),
-        ));
+        response = response
+            .insert_header((
+                "Content-Range",
+                format!(
+                    "bytes {}-{}/{}",
+                    range_start,
+                    range_start + res.content_length - 1,
+                    content_length
+                ),
+            ))
+            .insert_header(("Access-Control-Expose-Headers", "Content-Range"));
     }
 
     Ok(response.body(streaming_response))


### PR DESCRIPTION
otherwise, browsers cannot access it, because it's not among the CORS-safelisted response headers:
https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header

## What I'm changing

Responses to [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests) already include the [`Content-Range`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Range) header.

But browsers cannot read its value, because it's not among the [CORS-safelisted response headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header).

With this PR, the responses also include the header `Access-Control-Expose-Headers: Content-Range`, to allow browsers to access the `Content-Range` header.

## How I did it

I add the header, when the request was a range request.

## How to test it

Go to https://observablehq.com/@severo/bug-in-source-coop-content-range-is-not-accessible

Or test the following in a browser (not in Node.js)

```js
function test(url) {
  return fetch(url, { headers: { range: "bytes=0-100" } }).then((r) => 
    r.headers.get("Content-Range") === "bytes 0-100/70940" ? "Success": "Error"
  );
}
```

This function should return "Success" for any data file hosted by the proxy.

For example:

```js
test("https://data.source.coop/severo/csv-papaparse-test-files/verylong-sample.csv") // "Success"

// by comparison:
test("https://huggingface.co/datasets/severo/csv-papaparse-test-files/resolve/main/verylong-sample.csv") // "Success", since HF allows accessing this header
test("https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/severo/csv-papaparse-test-files/verylong-sample.csv") // "Error", since S3 does not allow accessing this header
```

## PR Checklist

- [x] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.

> I'm not a Rust developer, and the main.rs file has no tests, so: I don't feel comfortable creating tests in that file from scratch.

- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->
