### PR TITLE
perf: persist source client across requests

### DIFF
--- a/src/apis/source/mod.rs
+++ b/src/apis/source/mod.rs
@@ -119,8 +119,8 @@ pub struct SourceApi {
     /// Cache for user permissions
     permissions_cache: Arc<Cache<String, Vec<RepositoryPermission>>>,
 
-    /// Optional proxy URL for requests
-    proxy_url: Option<String>,
+    // API Client
+    client: reqwest::Client,
 }
 
 #[async_trait]
@@ -252,7 +252,6 @@ impl Api for SourceApi {
         account_id: String,
         user_identity: UserIdentity,
     ) -> Result<Account, BackendError> {
-        let client = self.build_req_client();
         // Create headers
         let mut headers = self.build_source_headers();
         if user_identity.api_key.is_some() {
@@ -266,7 +265,8 @@ impl Api for SourceApi {
             );
         }
 
-        let response = client
+        let response = self
+            .client
             .get(format!("{}/api/v1/products/{}", self.endpoint, account_id))
             .headers(headers)
             .send()
@@ -330,6 +330,15 @@ impl SourceApi {
                 .build(),
         );
 
+        let client = {
+            let mut client = reqwest::Client::builder()
+                .user_agent(concat!("source-proxy/", env!("CARGO_PKG_VERSION")));
+            if let Some(proxy) = proxy_url {
+                client = client.proxy(reqwest::Proxy::all(proxy).unwrap());
+            }
+            client.build().unwrap()
+        };
+
         SourceApi {
             endpoint,
             api_key,
@@ -337,21 +346,8 @@ impl SourceApi {
             data_connection_cache,
             access_key_cache,
             permissions_cache,
-            proxy_url,
+            client,
         }
-    }
-
-    /// Creates a new `reqwest::Client` with the appropriate proxy settings.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `reqwest::Client` with the appropriate proxy settings.
-    fn build_req_client(&self) -> reqwest::Client {
-        let mut client = reqwest::Client::builder();
-        if let Some(proxy) = &self.proxy_url {
-            client = client.proxy(reqwest::Proxy::all(proxy).unwrap());
-        }
-        client.build().unwrap()
     }
 
     /// Builds the headers for the Source API.
@@ -360,13 +356,7 @@ impl SourceApi {
     ///
     /// Returns a `reqwest::header::HeaderMap` with the appropriate headers.
     fn build_source_headers(&self) -> reqwest::header::HeaderMap {
-        const CORE_REQUEST_HEADERS: &[(&str, &str)] = &[
-            ("accept", "application/json"),
-            (
-                "user-agent",
-                concat!("source-proxy/", env!("CARGO_PKG_VERSION")),
-            ),
-        ];
+        const CORE_REQUEST_HEADERS: &[(&str, &str)] = &[("accept", "application/json")];
         CORE_REQUEST_HEADERS
             .iter()
             .map(|(name, value)| {
@@ -425,9 +415,8 @@ impl SourceApi {
             "{}/api/v1/products/{}/{}",
             self.endpoint, account_id, repository_id
         );
-        let client = self.build_req_client();
         let headers = self.build_source_headers();
-        let response = client.get(url).headers(headers).send().await?;
+        let response = self.client.get(url).headers(headers).send().await?;
         let repository =
             process_json_response::<SourceProduct>(response, BackendError::RepositoryNotFound)
                 .await?;
@@ -443,14 +432,14 @@ impl SourceApi {
         &self,
         data_connection_id: &str,
     ) -> Result<DataConnection, BackendError> {
-        let client = self.build_req_client();
         let mut headers = self.build_source_headers();
         headers.insert(
             reqwest::header::AUTHORIZATION,
             reqwest::header::HeaderValue::from_str(&self.api_key).unwrap(),
         );
 
-        let response = client
+        let response = self
+            .client
             .get(format!(
                 "{}/api/v1/data-connections/{}",
                 self.endpoint, data_connection_id
@@ -508,15 +497,14 @@ impl SourceApi {
     }
 
     async fn fetch_api_key(&self, access_key_id: String) -> Result<APIKey, BackendError> {
-        let client = self.build_req_client();
-
         // Create headers
         let mut headers = self.build_source_headers();
         headers.insert(
             reqwest::header::AUTHORIZATION,
             reqwest::header::HeaderValue::from_str(&self.api_key).unwrap(),
         );
-        let response = client
+        let response = self
+            .client
             .get(format!(
                 "{}/api/v1/api-keys/{access_key_id}/auth",
                 self.endpoint
@@ -588,8 +576,6 @@ impl SourceApi {
         account_id: &str,
         repository_id: &str,
     ) -> Result<Vec<RepositoryPermission>, BackendError> {
-        let client = self.build_req_client();
-
         // Create headers
         let mut headers = self.build_source_headers();
         if user_identity.api_key.is_some() {
@@ -603,7 +589,8 @@ impl SourceApi {
             );
         }
 
-        let response = client
+        let response = self
+            .client
             .get(format!(
                 "{}/api/v1/products/{account_id}/{repository_id}/permissions",
                 self.endpoint


### PR DESCRIPTION
## What I'm changing

In an effort to improve the data proxy's performance when communicating with the Source API, we can re-use our `reqwest::Client`.

From the [`reqwest::Client` Docs](https://docs.rs/reqwest/latest/reqwest/struct.Client.html):

> An asynchronous `Client` to make Requests with.
>
> ...
>
> The `Client` holds a connection pool internally, so it is advised that
> you create one and **reuse** it.
>
> You do **not** have to wrap the `Client` in an [`Rc`] or [`Arc`] to **reuse** it,
> because it already uses an [`Arc`] internally.


## How I did it

Rather than creating a new client on each outbound call to the Source API, we instead create it once when we initialize the `SourceApi` struct and utilize it to make API calls when needed.

<details>

<summary>Summary of discussion with Claude</summary>

```
  > Should we persists the reqwest client on the SourceApi struct for better performance? 
  
  ⏺ Great question! Let me analyze the current implementation and the potential benefits.
  
  ⏺ Read(src/apis/source/mod.rs)
    ⎿  Read 50 lines
  
  ⏺ Search(pattern: "build_req_client", path: "src/apis/source/mod.rs", output_mode: "content")
    ⎿  Found 6 lines (ctrl+o to expand)
  
  ⏺ Read(src/apis/source/mod.rs)
    ⎿  Read 15 lines
  
  ⏺ Read(src/apis/source/mod.rs)
    ⎿  Read 45 lines

  Yes, absolutely! This would be a significant performance improvement. Let me explain why:

  Current Issues

  Looking at the code, build_req_client() is called 5 times across different API methods:
  - get_account (line 255)
  - get_repository_record (line 428)
  - fetch_data_connection (line 446)
  - fetch_api_key (line 511)
  - fetch_permission (line 591)

  Each call creates a brand new reqwest::Client, which means:

  Performance Problems

  1. Lost Connection Pooling: reqwest::Client maintains an internal HTTP connection pool that reuses TCP connections. By creating a new client each time, you lose this major
  benefit - every request has to:
    - Perform a new DNS lookup
    - Establish a new TCP connection
    - Perform TLS handshake (for HTTPS)
    - Tear down the connection after use
  2. Resource Overhead: Each client initialization has CPU and memory overhead
  3. Against Best Practices: The reqwest documentation specifically recommends creating one client and reusing it

  Benefits of Persisting the Client

  1. Connection Reuse: Subsequent requests to api.source.coop can reuse existing TCP connections (~20-50ms savings per request)
  2. DNS Caching: The client caches DNS lookups internally
  3. Better Resource Management: Fewer file descriptors, more efficient connection management
  4. Thread Safe: reqwest::Client uses Arc internally, so it's cheap to clone and thread-safe - perfect for this struct that's already using Arc for caches

  Recommended Changes

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Ready to code?                                                                                                                                                                      │
│                                                                                                                                                                                     │
│ Here is Claude's plan:                                                                                                                                                              │
│ ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ Persist reqwest::Client on SourceApi                                                                                                                                            │ │
│ │                                                                                                                                                                                 │ │
│ │ Changes to make:                                                                                                                                                                │ │
│ │                                                                                                                                                                                 │ │
│ │ 1. Update SourceApi struct in src/apis/source/mod.rs:                                                                                                                           │ │
│ │   - Add client: reqwest::Client field (after proxy_url)                                                                                                                         │ │
│ │   - Add documentation explaining the client is reused for performance                                                                                                           │ │
│ │ 2. Update SourceApi::new() constructor:                                                                                                                                         │ │
│ │   - Build the reqwest::Client once during initialization                                                                                                                        │ │
│ │   - Store it in the struct instead of building it on every request                                                                                                              │ │
│ │ 3. Update all API methods:                                                                                                                                                      │ │
│ │   - Replace 5 calls to self.build_req_client() with &self.client                                                                                                                │ │
│ │   - Methods: get_account, get_repository_record, fetch_data_connection, fetch_api_key, fetch_permission                                                                         │ │
│ │ 4. Remove build_req_client() method:                                                                                                                                            │ │
│ │   - No longer needed since client is initialized once                                                                                                                           │ │
│ │                                                                                                                                                                                 │ │
│ │ Performance Impact:                                                                                                                                                             │ │
│ │ - Enables HTTP connection pooling and reuse                                                                                                                                     │ │
│ │ - Reduces latency by ~20-50ms per request (avoiding TCP handshake + TLS)                                                                                                        │ │
│ │ - Better resource utilization                                                                                                                                                   │ │
│ │ - Follows reqwest best practices                                                                                                                                                │ │
│ │                                                                                                                                                                                 │ │
│ │ Risk: Very low - reqwest::Client is designed for this pattern and the struct is already Clone-compatible                                                                        │ │
│ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
```

</details>


## How to test it

<!-- Inform the reviewer how they can validate that these changes work -->

## PR Checklist

- [ ] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

<!-- Reference any existing related GitHub Issues -->
