### PR TITLE
feat: Indicate range request support with Accept-Ranges header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,8 @@ async fn get_object(
     };
 
     let mut response = response
+        .insert_header(("Accept-Ranges", "bytes"))
+        .insert_header(("Access-Control-Expose-Headers", "Accept-Ranges"))
         .insert_header(("Content-Type", res.content_type))
         .insert_header(("Last-Modified", res.last_modified))
         .insert_header(("Content-Length", res.content_length.to_string()))
@@ -133,7 +135,10 @@ async fn get_object(
                     content_length
                 ),
             ))
-            .insert_header(("Access-Control-Expose-Headers", "Content-Range"));
+            .insert_header((
+                "Access-Control-Expose-Headers",
+                "Accept-Ranges, Content-Range",
+            ));
     }
 
     Ok(response.body(streaming_response))
@@ -351,6 +356,8 @@ async fn head_object(
 
     let res = client.head_object(key.clone()).await?;
     Ok(HttpResponse::Ok()
+        .insert_header(("Accept-Ranges", "bytes"))
+        .insert_header(("Access-Control-Expose-Headers", "Accept-Ranges"))
         .insert_header(("Content-Type", res.content_type))
         .insert_header(("Last-Modified", res.last_modified))
         .insert_header(("ETag", res.etag))


### PR DESCRIPTION
## What I'm changing

This appends the [`Accept-Ranges`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges) header to GET and HEAD responses for objects, indicating support for HTTP range requests. Since some clients look for this header, it should improve use of range requests.

Addresses https://github.com/source-cooperative/data.source.coop/issues/103.

## How I did it

`get_object` and `head_object` responses now include `Accept-Ranges`, as well as `Access-Control-Expose-Headers` for CORS safelisting.

## How to test it

When running the proxy:

* Perform a HEAD or GET request for an object
* Check the response headers; `Accept-Ranges: bytes` and `Access-Control-Expose-Headers: Accept-Ranges` should both be present

## PR Checklist

- [x] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

[[Proposed Feature] Indicate range request support with Accept-Ranges header](https://github.com/source-cooperative/data.source.coop/issues/103)