### PR TITLE
fix: update multistore to properly recognize directory markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,8 +787,9 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.3.0"
-source = "git+https://github.com/developmentseed/multistore.git?branch=fix%2Fdirectory-marker-support#0e493ef49e6c04ec356027cc910db56bf6214e30"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b8ee9b42e77900a5378712d1e4f295e89fb30135d2a65426d29ac6ddd50c66"
 dependencies = [
  "async-trait",
  "base64",
@@ -813,8 +814,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.3.0"
-source = "git+https://github.com/developmentseed/multistore.git?branch=fix%2Fdirectory-marker-support#0e493ef49e6c04ec356027cc910db56bf6214e30"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2c455b78a8d5591d0f28e4968b718c419324a0e32d4081322dec8d7b378bb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -836,8 +838,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.3.0"
-source = "git+https://github.com/developmentseed/multistore.git?branch=fix%2Fdirectory-marker-support#0e493ef49e6c04ec356027cc910db56bf6214e30"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc12426dcc148af09dcb4fed8ccae767c8841f6d8a381201ae737bb359450f68"
 dependencies = [
  "multistore",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { git = "https://github.com/developmentseed/multistore.git", branch = "fix/directory-marker-support", features = ["azure"] }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", branch = "fix/directory-marker-support" }
+multistore = { version = "0.3.1", features = ["azure"] }
+multistore-path-mapping = "0.3.1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -36,7 +36,7 @@ tracing = "0.1"
 
 # Wasm-only dependencies (Cloudflare Workers runtime)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", branch = "fix/directory-marker-support", features = ["azure"] }
+multistore-cf-workers = { version = "0.3.1", features = ["azure"] }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"


### PR DESCRIPTION
## What I'm changing

Bump `multistore` version to [v0.3.1](https://github.com/developmentseed/multistore/releases/tag/v0.3.1) to support directory markers (https://github.com/developmentseed/multistore/pull/22).

<!-- Describe the high-level goals of the change -->

## How I did it

Updated multistore to ignore any keys returned by the object store backend that has 0 bytes and ends with `/` (these keys are still returned as `CommonPrefixes`, but not `Objects`)

<!-- Discuss the implementation strategy and considerations made -->

## How to test it

This backend is currently enabled as the backend of https://source-cooperative-git-feat-data-connection-admin-radiantearth.vercel.app. As such, compare the following:

* Before: https://staging.source.coop/harvard-lil/staging-gov-data
* After: https://source-cooperative-git-feat-data-connection-admin-radiantearth.vercel.app/harvard-lil/staging-gov-data

You'll see an empty `staging-gov-data` in the before, but no longer in the after.

<!-- Inform the reviewer how they can validate that these changes work -->

## PR Checklist

- [ ] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

Resolves https://github.com/source-cooperative/source.coop/issues/245