### PR TITLE
feat: OIDC provider

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -23,4 +23,27 @@ ignore = [
     # Revisit when: the `rsa` crate ships a fix, or `multistore-oidc-provider`
     # migrates to a different RSA/signing implementation (e.g. ES256).
     "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2026-0097: `rand` is unsound with a custom logger using `rand::rng()`
+    #
+    # This is a soundness warning (not a vulnerability) affecting `rand` 0.8.5
+    # and 0.9.2. The unsoundness is only triggerable when a custom `log`
+    # implementation calls back into `rand::rng()` from within its `log()` method,
+    # creating reentrant access to thread-local RNG state.
+    #
+    # This does not affect us because:
+    #
+    # 1. We pull `rand` in only via transitive dependencies (`rsa`,
+    #    `num-bigint-dig`, `quinn-proto`, `object_store`) — we do not call
+    #    `rand::rng()` directly, and our logging setup does not invoke the RNG
+    #    from inside log handlers.
+    #
+    # 2. No fixed version exists in the 0.8.x or 0.9.x series. The advisory
+    #    lists no Solution; upstream has not released a patch on a compatible
+    #    semver line, and our transitive deps pin these majors.
+    #
+    # Revisit when: `rand` ships a patched 0.8.x/0.9.x release, or our
+    # transitive deps (`rsa`, `quinn-proto`, `object_store`) upgrade to
+    # `rand` 0.10+.
+    "RUSTSEC-2026-0097",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,26 @@
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071: Marvin Attack on the `rsa` crate (medium severity, 5.9)
+    #
+    # This advisory covers a timing side-channel in RSA PKCS#1 v1.5 *decryption*
+    # that could allow an attacker to recover plaintext by observing response
+    # times across many crafted ciphertexts.
+    #
+    # This does not affect us because:
+    #
+    # 1. We only use RSA for *signing* (PKCS#1 v1.5 with SHA-256 via
+    #    `SigningKey::<Sha256>`). The vulnerable code path is in the decryption
+    #    routine, which we never call.
+    #
+    # 2. The private key never processes attacker-controlled input. The proxy
+    #    signs its own JWTs with claims it constructs — no external ciphertext
+    #    is ever decrypted.
+    #
+    # 3. No fixed version exists. The `rsa` crate has not released a patch as
+    #    of 0.9.x. If a fix or alternative crate becomes available upstream in
+    #    `multistore-oidc-provider`, we should adopt it and remove this ignore.
+    #
+    # Revisit when: the `rsa` crate ships a fix, or `multistore-oidc-provider`
+    # migrates to a different RSA/signing implementation (e.g. ES256).
+    "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           } > .dev.vars
       - name: Start wrangler dev
         run: |
+          sed -i 's/^command = .*/command = "echo skip"/' wrangler.toml
           wrangler dev --port 8787 --no-bundle &
           curl --retry 120 --retry-delay 1 --retry-connrefused --silent --fail http://localhost:8787/ > /dev/null
           echo "Server ready"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,20 @@ jobs:
         run: npm install -g wrangler@3
       - name: Install worker-build
         run: cargo install worker-build@0.7.5
+      - name: Generate test secrets
+        # Required by `load_config` in src/config.rs. The actual key material
+        # doesn't matter for these read-only public-data tests — we just need
+        # values that parse, since `JwtSigner::from_pem` and `TokenKey::from_base64`
+        # validate at startup.
+        run: |
+          openssl genpkey -algorithm RSA -out /tmp/oidc.pem -pkeyopt rsa_keygen_bits:2048
+          {
+            printf 'OIDC_PROVIDER_KEY="'
+            cat /tmp/oidc.pem
+            printf '"\n'
+            echo "SESSION_TOKEN_KEY=$(openssl rand -base64 32)"
+            echo "AUTH_ISSUER=https://auth.test.example.com"
+          } > .dev.vars
       - name: Start wrangler dev
         run: |
           wrangler dev --port 8787 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,10 @@ jobs:
           } > .dev.vars
       - name: Start wrangler dev
         run: |
-          sed -i 's/^command = .*/command = "echo skip"/' wrangler.toml
+          # Skip the build command (the artifact is prebuilt). Scope the
+          # rewrite to the [build] section so other `command =` lines that
+          # may appear later in the config are untouched.
+          sed -i '/^\[build\]/,/^\[/ s/^command = .*/command = "echo skip"/' wrangler.toml
           wrangler dev --port 8787 &
           curl --retry 120 --retry-delay 1 --retry-connrefused --silent --fail http://localhost:8787/ > /dev/null
           echo "Server ready"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,12 @@ jobs:
         run: cargo install worker-build@0.7.5
       - name: Build WASM worker
         run: worker-build --release
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: worker-build
+          path: build/
+          retention-days: 1
 
   integration:
     name: Integration Tests
@@ -72,18 +78,16 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/download-artifact@v4
         with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+          name: worker-build
+          path: build/
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
       - uses: astral-sh/setup-uv@v5
       - name: Install wrangler
         run: npm install -g wrangler@3
-      - name: Install worker-build
-        run: cargo install worker-build@0.7.5
       - name: Generate test secrets
         # Required by `load_config` in src/config.rs. The actual key material
         # doesn't matter for these read-only public-data tests — we just need
@@ -100,7 +104,7 @@ jobs:
           } > .dev.vars
       - name: Start wrangler dev
         run: |
-          wrangler dev --port 8787 &
+          wrangler dev --port 8787 --no-bundle &
           curl --retry 120 --retry-delay 1 --retry-connrefused --silent --fail http://localhost:8787/ > /dev/null
           echo "Server ready"
       - name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,8 @@ jobs:
       - name: Start wrangler dev
         run: |
           wrangler dev --port 8787 &
-          for i in $(seq 1 60); do
-            if curl -s --max-time 2 http://localhost:8787/ > /dev/null 2>&1; then
-              echo "Server ready after ${i}s"
-              break
-            fi
-            sleep 1
-          done
+          curl --retry 120 --retry-delay 1 --retry-connrefused --silent --fail http://localhost:8787/ > /dev/null
+          echo "Server ready"
       - name: Run integration tests
         run: uvx --with requests pytest tests/ -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Start wrangler dev
         run: |
           sed -i 's/^command = .*/command = "echo skip"/' wrangler.toml
-          wrangler dev --port 8787 --no-bundle &
+          wrangler dev --port 8787 &
           curl --retry 120 --retry-delay 1 --retry-connrefused --silent --fail http://localhost:8787/ > /dev/null
           echo "Server ready"
       - name: Run integration tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ on:
         required: true
       CLOUDFLARE_ACCOUNT_ID:
         required: true
+      OIDC_PROVIDER_KEY:
+        required: true
 
 jobs:
   deploy:
@@ -87,6 +89,17 @@ jobs:
             EXTRA_ARGS="$EXTRA_ARGS --var $var"
           done
           npx wrangler@3 deploy --config ${{ inputs.wrangler_config }} $EXTRA_ARGS
+
+      - name: Upload worker secrets
+        run: |
+          WORKER_ARGS=""
+          if [ -n "${{ inputs.wrangler_env }}" ]; then
+            WORKER_ARGS="--env ${{ inputs.wrangler_env }}"
+          fi
+          if [ -n "${{ inputs.worker_name }}" ]; then
+            WORKER_ARGS="--name ${{ inputs.worker_name }}"
+          fi
+          echo '{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}}' | npx wrangler@3 secret bulk $WORKER_ARGS
 
       - name: Get deploy URL
         id: url

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,8 @@ on:
         required: true
       OIDC_PROVIDER_KEY:
         required: true
+      SESSION_TOKEN_KEY:
+        required: false
 
 jobs:
   deploy:
@@ -99,7 +101,11 @@ jobs:
           if [ -n "${{ inputs.worker_name }}" ]; then
             WORKER_ARGS="--name ${{ inputs.worker_name }}"
           fi
-          echo '{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}}' | npx wrangler@3 secret bulk $WORKER_ARGS
+          SECRETS='{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}}'
+          if [ -n "${{ secrets.SESSION_TOKEN_KEY }}" ]; then
+            SECRETS=$(echo "$SECRETS" | jq --arg key "${{ secrets.SESSION_TOKEN_KEY }}" '. + {SESSION_TOKEN_KEY: $key}')
+          fi
+          echo "$SECRETS" | npx wrangler@3 secret bulk $WORKER_ARGS
 
       - name: Get deploy URL
         id: url

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ on:
       OIDC_PROVIDER_KEY:
         required: true
       SESSION_TOKEN_KEY:
-        required: false
+        required: true
 
 jobs:
   deploy:
@@ -101,10 +101,7 @@ jobs:
           if [ -n "${{ inputs.worker_name }}" ]; then
             WORKER_ARGS="--name ${{ inputs.worker_name }}"
           fi
-          SECRETS='{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}}'
-          if [ -n "${{ secrets.SESSION_TOKEN_KEY }}" ]; then
-            SECRETS=$(echo "$SECRETS" | jq --arg key "${{ secrets.SESSION_TOKEN_KEY }}" '. + {SESSION_TOKEN_KEY: $key}')
-          fi
+          SECRETS='{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}, "SESSION_TOKEN_KEY": ${{ toJSON(secrets.SESSION_TOKEN_KEY) }}}'
           echo "$SECRETS" | npx wrangler@3 secret bulk $WORKER_ARGS
 
       - name: Get deploy URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,8 @@ on:
         required: true
       SESSION_TOKEN_KEY:
         required: true
+      OIDC_PROVIDER_KEY_PREVIOUS:
+        required: false
 
 jobs:
   deploy:
@@ -93,6 +95,14 @@ jobs:
           npx wrangler@3 deploy --config ${{ inputs.wrangler_config }} $EXTRA_ARGS
 
       - name: Upload worker secrets
+        # GitHub environment secrets are the source of truth — anything set
+        # here is re-uploaded on every deploy, overwriting values set manually
+        # via `wrangler secret put`. OIDC_PROVIDER_KEY_PREVIOUS is included
+        # only while a rotation is in progress (i.e. the GitHub secret exists).
+        env:
+          OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
+          SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
+          OIDC_PROVIDER_KEY_PREVIOUS: ${{ secrets.OIDC_PROVIDER_KEY_PREVIOUS }}
         run: |
           WORKER_ARGS=""
           if [ -n "${{ inputs.wrangler_env }}" ]; then
@@ -101,8 +111,9 @@ jobs:
           if [ -n "${{ inputs.worker_name }}" ]; then
             WORKER_ARGS="--name ${{ inputs.worker_name }}"
           fi
-          SECRETS='{"OIDC_PROVIDER_KEY": ${{ toJSON(secrets.OIDC_PROVIDER_KEY) }}, "SESSION_TOKEN_KEY": ${{ toJSON(secrets.SESSION_TOKEN_KEY) }}}'
-          echo "$SECRETS" | npx wrangler@3 secret bulk $WORKER_ARGS
+          jq -n '{OIDC_PROVIDER_KEY: env.OIDC_PROVIDER_KEY, SESSION_TOKEN_KEY: env.SESSION_TOKEN_KEY}
+                 + (if (env.OIDC_PROVIDER_KEY_PREVIOUS // "") != "" then {OIDC_PROVIDER_KEY_PREVIOUS: env.OIDC_PROVIDER_KEY_PREVIOUS} else {} end)' \
+            | npx wrangler@3 secret bulk $WORKER_ARGS
 
       - name: Get deploy URL
         id: url

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,12 @@ jobs:
           SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
           OIDC_PROVIDER_KEY_PREVIOUS: ${{ secrets.OIDC_PROVIDER_KEY_PREVIOUS }}
         run: |
+          # Fail loudly if a required secret is missing/empty in this GitHub
+          # environment. Without this, jq emits an empty value, `secret bulk`
+          # succeeds, the job goes green — and every request to the worker
+          # panics in load_config (the worker cannot boot without these).
+          [ -n "$OIDC_PROVIDER_KEY" ] || { echo "::error::OIDC_PROVIDER_KEY is not set in the '${{ inputs.environment }}' environment"; exit 1; }
+          [ -n "$SESSION_TOKEN_KEY" ] || { echo "::error::SESSION_TOKEN_KEY is not set in the '${{ inputs.environment }}' environment"; exit 1; }
           WORKER_ARGS=""
           if [ -n "${{ inputs.wrangler_env }}" ]; then
             WORKER_ARGS="--env ${{ inputs.wrangler_env }}"
@@ -121,3 +127,24 @@ jobs:
           WORKER="${{ inputs.worker_name || 'source-data-proxy' }}"
           URL="https://${WORKER}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev"
           echo "deploy_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test
+        # Confirm the worker actually booted. A missing/malformed secret makes
+        # load_config panic on the first request (Cloudflare 1101 → HTTP 5xx),
+        # so this turns a silently-broken deploy into a red job.
+        run: |
+          URL="${{ steps.url.outputs.deploy_url }}"
+          echo "Smoke-testing $URL"
+          for path in "/" "/.well-known/jwks.json"; do
+            ok=""
+            for attempt in 1 2 3 4 5; do
+              if code=$(curl -fsS -o /dev/null -w '%{http_code}' "$URL$path"); then
+                echo "ok: $path -> $code"
+                ok=1
+                break
+              fi
+              echo "attempt $attempt: $path not ready, retrying in 3s…"
+              sleep 3
+            done
+            [ -n "$ok" ] || { echo "::error::smoke test failed for $URL$path"; exit 1; }
+          done

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,6 +31,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
       SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
+      OIDC_PROVIDER_KEY_PREVIOUS: ${{ secrets.OIDC_PROVIDER_KEY_PREVIOUS }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,12 +22,15 @@ jobs:
         SOURCE_API_URL:https://staging.source.coop
         OIDC_PROVIDER_ISSUER:https://source-data-proxy-pr-${{ github.event.pull_request.number }}.source-coop.workers.dev
         OIDC_PROVIDER_KID:source-proxy-1
-      service_overrides: "PUBLIC_LOG_STREAM:public-log-stream-pr-${{ github.event.pull_request.number }}"
+        AUTH_ISSUER:https://auth.staging.source.coop
+      service_overrides: >-
+        PUBLIC_LOG_STREAM:public-log-stream-pr-${{ github.event.pull_request.number }}
       environment: preview
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
+      SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,12 +17,13 @@ jobs:
     with:
       worker_name: source-data-proxy-pr-${{ github.event.pull_request.number }}
       wrangler_config: wrangler.preview.toml
-      var_overrides: "LOG_LEVEL:DEBUG SOURCE_API_URL:https://staging.source.coop"
+      var_overrides: "LOG_LEVEL:DEBUG SOURCE_API_URL:https://staging.source.coop OIDC_PROVIDER_ISSUER:https://data.staging.source.coop OIDC_PROVIDER_KID:source-proxy-1"
       service_overrides: "PUBLIC_LOG_STREAM:public-log-stream-pr-${{ github.event.pull_request.number }}"
       environment: preview
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,11 @@ jobs:
     with:
       worker_name: source-data-proxy-pr-${{ github.event.pull_request.number }}
       wrangler_config: wrangler.preview.toml
-      var_overrides: "LOG_LEVEL:DEBUG SOURCE_API_URL:https://staging.source.coop OIDC_PROVIDER_ISSUER:https://data.staging.source.coop OIDC_PROVIDER_KID:source-proxy-1"
+      var_overrides: >-
+        LOG_LEVEL:DEBUG
+        SOURCE_API_URL:https://staging.source.coop
+        OIDC_PROVIDER_ISSUER:https://source-data-proxy-pr-${{ github.event.pull_request.number }}.source-coop.workers.dev
+        OIDC_PROVIDER_KID:source-proxy-1
       service_overrides: "PUBLIC_LOG_STREAM:public-log-stream-pr-${{ github.event.pull_request.number }}"
       environment: preview
     secrets:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -21,6 +21,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
       SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
+      OIDC_PROVIDER_KEY_PREVIOUS: ${{ secrets.OIDC_PROVIDER_KEY_PREVIOUS }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,6 +19,8 @@ jobs:
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
+      SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,6 +21,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
       SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
+      OIDC_PROVIDER_KEY_PREVIOUS: ${{ secrets.OIDC_PROVIDER_KEY_PREVIOUS }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,6 +19,8 @@ jobs:
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      OIDC_PROVIDER_KEY: ${{ secrets.OIDC_PROVIDER_KEY }}
+      SESSION_TOKEN_KEY: ${{ secrets.SESSION_TOKEN_KEY }}
 
   deploy-public-log-stream:
     name: Deploy Public Log Stream

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules
 docs/plans
 .worktrees
+.dev.vars

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,7 @@ dependencies = [
  "multistore-oidc-provider",
  "multistore-path-mapping",
  "multistore-sts",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
 dependencies = [
  "async-trait",
  "base64",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
 dependencies = [
  "async-trait",
  "base64",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
 dependencies = [
  "async-trait",
  "base64",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
 dependencies = [
  "async-trait",
  "base64",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,8 +894,8 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
+version = "0.4.0"
+source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
 dependencies = [
  "async-trait",
  "base64",
@@ -920,8 +920,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
+version = "0.4.0"
+source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
 dependencies = [
  "async-trait",
  "bytes",
@@ -934,6 +934,7 @@ dependencies = [
  "js-sys",
  "multistore",
  "object_store",
+ "percent-encoding",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -943,8 +944,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
+version = "0.4.0"
+source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
 dependencies = [
  "async-trait",
  "base64",
@@ -961,8 +962,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
+version = "0.4.0"
+source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -971,8 +972,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#93a678a0a527a5f6a8d95e66e4d21f8cb6c4d1c7"
+version = "0.4.0"
+source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1701,7 +1702,6 @@ name = "source-data-proxy"
 version = "2.1.0"
 dependencies = [
  "console_error_panic_hook",
- "futures",
  "http",
  "js-sys",
  "multistore",
@@ -1709,13 +1709,11 @@ dependencies = [
  "multistore-oidc-provider",
  "multistore-path-mapping",
  "multistore-sts",
- "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
  "tracing",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "worker",
  "worker-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,17 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -708,6 +725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +744,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -837,6 +869,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "multistore-oidc-provider"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9d04c6333a0643ffa46470fba8eb1ae4d53667cbe241c8cdb3921d063c6ec6"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "multistore",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,12 +899,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -878,7 +966,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "serde",
@@ -928,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1061,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1051,7 +1169,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1100,12 +1218,32 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1115,7 +1253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1190,6 +1337,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1385,6 +1552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1593,7 @@ dependencies = [
  "js-sys",
  "multistore",
  "multistore-cf-workers",
+ "multistore-oidc-provider",
  "multistore-path-mapping",
  "percent-encoding",
  "serde",
@@ -1426,6 +1604,22 @@ dependencies = [
  "web-sys",
  "worker",
  "worker-macros",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,8 +820,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b8ee9b42e77900a5378712d1e4f295e89fb30135d2a65426d29ac6ddd50c66"
+source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
 dependencies = [
  "async-trait",
  "base64",
@@ -847,8 +846,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2c455b78a8d5591d0f28e4968b718c419324a0e32d4081322dec8d7b378bb"
+source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -871,8 +869,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9d04c6333a0643ffa46470fba8eb1ae4d53667cbe241c8cdb3921d063c6ec6"
+source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
 dependencies = [
  "async-trait",
  "base64",
@@ -890,8 +887,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc12426dcc148af09dcb4fed8ccae767c8841f6d8a381201ae737bb359450f68"
+source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
 dependencies = [
  "multistore",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
 dependencies = [
  "async-trait",
  "base64",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
 dependencies = [
  "async-trait",
  "base64",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.3.1"
-source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#22d606b3e6fa03bea67642f4bcaf9a818c36165d"
+source = "git+https://github.com/developmentseed/multistore.git?branch=feat%2Fauth%2Frewritten-path-support#719f7c82dd0ce4154b548f25307d69314ba4509b"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,8 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7fb1fa70d7a75a57e322825fa61da83bfaef5a6e705ad871b8bad46db55b"
 dependencies = [
  "async-trait",
  "base64",
@@ -935,7 +936,8 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941b094b16c87594cdda4952e52c1a70bc19ca8a89985fc8d63a82b9b7feb6a9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -959,7 +961,8 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249fb5386150184f591170ddfb0916ae9fe1861c3523d8ae84b638cad22f5e76"
 dependencies = [
  "async-trait",
  "base64",
@@ -977,7 +980,8 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1f27fa70820affb7056520372cbf337fa7739056bf6f0e63b4b5870aeb5a8e"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -987,7 +991,8 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore.git?tag=v0.4.0#0e38dca4bc62816a888cc132bc0b05093b8d1c91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d147130ee410a7f429ab4d8fa1be0f391be43682d3582bf0393e184d705a722a"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +151,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +208,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -378,6 +433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +579,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -684,6 +750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +895,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.3.1"
-source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
+source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
 dependencies = [
  "async-trait",
  "base64",
@@ -846,7 +921,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.3.1"
-source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
+source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -869,7 +944,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.3.1"
-source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
+source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
 dependencies = [
  "async-trait",
  "base64",
@@ -887,11 +962,33 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.3.1"
-source = "git+https://github.com/alukach/multistore.git?branch=feat%2Foidc%2Fsupport-multiple-signing-keys#42dd5965203d69c5199e21ecc6f70ac8a5bb89f4"
+source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
 dependencies = [
  "multistore",
  "percent-encoding",
  "tracing",
+]
+
+[[package]]
+name = "multistore-sts"
+version = "0.3.1"
+source = "git+https://github.com/developmentseed/multistore.git?branch=main#ff12fe37ea38f1da9d96d98e7412cc46ffbecef8"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "base64",
+ "chrono",
+ "multistore",
+ "quick-xml 0.37.5",
+ "rand 0.8.5",
+ "reqwest",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -981,6 +1078,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1077,6 +1180,18 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1218,6 +1333,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -1319,6 +1435,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1591,7 +1708,9 @@ dependencies = [
  "multistore-cf-workers",
  "multistore-oidc-provider",
  "multistore-path-mapping",
+ "multistore-sts",
  "percent-encoding",
+ "reqwest",
  "serde",
  "serde_json",
  "tracing",
@@ -1856,6 +1975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2182,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "tests/pagination.rs"
 [dependencies]
 # Multistore
 multistore = { version = "0.3.1", features = ["azure"] }
+multistore-oidc-provider = "0.3.1"
 multistore-path-mapping = "0.3.1"
 
 # Serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys", features = ["azure"] }
-multistore-oidc-provider = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys" }
-multistore-path-mapping = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys" }
+multistore = { git = "https://github.com/developmentseed/multistore.git", branch = "main", features = ["azure"] }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -37,7 +38,8 @@ tracing = "0.1"
 
 # Wasm-only dependencies (Cloudflare Workers runtime)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-multistore-cf-workers = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys", features = ["azure"] }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", branch = "main", features = ["azure"] }
+reqwest = { version = "0.12", default-features = false }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { version = "0.3.1", features = ["azure"] }
-multistore-oidc-provider = "0.3.1"
-multistore-path-mapping = "0.3.1"
+multistore = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys", features = ["azure"] }
+multistore-oidc-provider = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys" }
+multistore-path-mapping = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -37,7 +37,7 @@ tracing = "0.1"
 
 # Wasm-only dependencies (Cloudflare Workers runtime)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-multistore-cf-workers = { version = "0.3.1", features = ["azure"] }
+multistore-cf-workers = { git = "https://github.com/alukach/multistore.git", branch = "feat/oidc/support-multiple-signing-keys", features = ["azure"] }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1"
 
 # HTTP
 http = "1"
+percent-encoding = "2"
 
 # Tracing
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "2.1.0"
 
 [lib]
 crate-type = ["cdylib"]
-# The cdylib depends on wasm-only crates (worker, wasm-bindgen-futures, web-sys)
+# The cdylib depends on wasm-only crates (worker, wasm-bindgen, web-sys)
 # that don't compile on native targets, so we disable `cargo test` for the lib.
 test = false
 
@@ -20,10 +20,10 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support", features = ["azure"] }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
+multistore = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0", features = ["azure"] }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -31,17 +31,14 @@ serde_json = "1"
 
 # HTTP
 http = "1"
-percent-encoding = "2"
 
 # Tracing
 tracing = "0.1"
 
 # Wasm-only dependencies (Cloudflare Workers runtime)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support", features = ["azure"] }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0", features = ["azure"] }
 reqwest = { version = "0.12", default-features = false }
-futures = "0.3"
-wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0", features = ["azure"] }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0" }
+multistore = { version = "0.4.0", features = ["azure"] }
+multistore-oidc-provider = { version = "0.4.0" }
+multistore-path-mapping = { version = "0.4.0" }
+multistore-sts = { version = "0.4.0" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -40,7 +40,7 @@ tracing = "0.1"
 # Pulled in transitively via object_store -> rand. getrandom doesn't support
 # wasm32-unknown-unknown unless the `wasm_js` backend is enabled, so opt in here.
 getrandom = { version = "0.4", features = ["wasm_js"] }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", tag = "v0.4.0", features = ["azure"] }
+multistore-cf-workers = { version = "0.4.0", features = ["azure"] }
 reqwest = { version = "0.12", default-features = false }
 console_error_panic_hook = "0.1"
 js-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ tracing = "0.1"
 # wasm32-unknown-unknown unless the `wasm_js` backend is enabled, so opt in here.
 getrandom = { version = "0.4", features = ["wasm_js"] }
 multistore-cf-workers = { version = "0.4.0", features = ["azure"] }
+# On wasm32-unknown-unknown reqwest selects its browser `fetch` backend by
+# target arch (not a cargo feature), so the default TLS/backend features are
+# unnecessary here. We only use `Client::new()`, `.send()` and `.text()`, none
+# of which are feature-gated -- so no explicit feature list is required.
 reqwest = { version = "0.12", default-features = false }
 console_error_panic_hook = "0.1"
 js-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ path = "tests/pagination.rs"
 
 [dependencies]
 # Multistore
-multistore = { git = "https://github.com/developmentseed/multistore.git", branch = "main", features = ["azure"] }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore.git", branch = "main" }
+multistore = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support", features = ["azure"] }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -38,7 +38,7 @@ tracing = "0.1"
 
 # Wasm-only dependencies (Cloudflare Workers runtime)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", branch = "main", features = ["azure"] }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore.git", branch = "feat/auth/rewritten-path-support", features = ["azure"] }
 reqwest = { version = "0.12", default-features = false }
 futures = "0.3"
 wasm-bindgen-futures = "0.4"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The proxy rewrites Source Cooperative URL paths (`/{account}/{product}/{key}`) i
 ```
 Client Request: GET /{account}/{product}/{key}
   │
-  ├─ [routing]   Parse path, rewrite to bucket={account}--{product}, key={key}
+  ├─ [routing]   Parse path, rewrite to bucket={account}:{product}, key={key}
   ├─ [registry]  Resolve backend via Source API (product metadata + data connections)
   ├─ [cache]     Cache API responses (products: 5min, data connections: 30min, listings: 1min)
   ├─ [multistore ProxyGateway]  Generate presigned URL for the resolved storage backend
@@ -77,11 +77,13 @@ Client Request: GET /{account}/{product}/{key}
 
 | Module | Purpose |
 |---|---|
-| `src/lib.rs` | Fetch handler, request routing, CORS |
+| `src/lib.rs` | Fetch handler, OIDC discovery endpoints, request routing, CORS |
 | `src/routing.rs` | Request classification and path rewriting |
 | `src/registry.rs` | Source Cooperative API client and backend resolution |
 | `src/cache.rs` | Cloudflare Cache API wrapper with per-datatype TTLs |
 | `src/pagination.rs` | S3-compatible pagination for prefix listings |
+| `src/analytics.rs` | Cloudflare Analytics Engine request logging |
+| `src/handlers.rs` | Custom route handlers (index, account listing) |
 
 ### Supported Operations
 
@@ -93,18 +95,107 @@ Client Request: GET /{account}/{product}/{key}
 | `GET /{account}/{product}/{key}` | Download an object (supports range requests) |
 | `HEAD /{account}/{product}/{key}` | Get object metadata |
 | `OPTIONS *` | CORS preflight |
+| `GET /.well-known/openid-configuration` | OIDC discovery document |
+| `GET /.well-known/jwks.json` | JSON Web Key Set for JWT verification |
 
 Write operations (`PUT`, `POST`, `DELETE`, `PATCH`) return `405 Method Not Allowed`.
 
 ## Configuration
 
-Environment variables (set in `wrangler.toml` or via Cloudflare dashboard):
+### Environment Variables
+
+Set in `wrangler.toml` or via the Cloudflare dashboard:
 
 | Variable | Default | Description |
 |---|---|---|
 | `SOURCE_API_URL` | `https://source.coop` | Source Cooperative API base URL |
-| `SOURCE_API_SECRET` | — | Optional API authentication token |
 | `LOG_LEVEL` | `WARN` | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`) |
+| `OIDC_PROVIDER_ISSUER` | `https://data.source.coop` | Issuer URL for minted JWTs and OIDC discovery |
+| `OIDC_PROVIDER_KID` | `data-proxy-1` | Key ID for the active signing key |
+| `OIDC_PROVIDER_KID_PREVIOUS` | — | Key ID for the previous key (during rotation) |
+
+### Secrets
+
+Set via `wrangler secret put`:
+
+| Secret | Description |
+|---|---|
+| `SOURCE_API_SECRET` | Static API token (legacy fallback, used when OIDC is not configured) |
+| `OIDC_PROVIDER_KEY` | PEM-encoded PKCS#8 RSA private key for JWT signing |
+| `OIDC_PROVIDER_KEY_PREVIOUS` | Previous RSA key (optional, during rotation) |
+
+### Authentication Priority
+
+The proxy authenticates to the Source Cooperative API in this order:
+
+1. **OIDC JWT** — if `OIDC_PROVIDER_KEY` is set, the proxy mints a short-lived JWT (60s TTL) signed with its RSA key and sends it as a `Bearer` token
+2. **Static secret** — if only `SOURCE_API_SECRET` is set, it is sent as the `Authorization` header
+3. **None** — if neither is configured, requests are unauthenticated
+
+## OIDC Provider
+
+When configured with an RSA key, the proxy acts as its own OpenID Connect identity provider. It serves standard discovery endpoints so that relying parties (such as the Source Cooperative API) can verify its JWTs.
+
+### Endpoints
+
+- `GET /.well-known/openid-configuration` — discovery document containing issuer and JWKS URI
+- `GET /.well-known/jwks.json` — public key(s) for JWT signature verification
+
+These endpoints are only active when `OIDC_PROVIDER_KEY` is configured.
+
+### Setup
+
+Generate an RSA key pair and deploy it:
+
+```sh
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out oidc-key.pem
+wrangler secret put OIDC_PROVIDER_KEY < oidc-key.pem
+wrangler deploy
+```
+
+Verify the endpoints:
+
+```sh
+curl https://data.source.coop/.well-known/openid-configuration
+curl https://data.source.coop/.well-known/jwks.json
+```
+
+### Key Rotation
+
+The proxy supports zero-downtime key rotation by serving both active and previous public keys in the JWKS endpoint. Only the active key signs new tokens.
+
+**Rotation procedure:**
+
+1. Generate a new RSA key with a new key ID:
+
+   ```sh
+   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out new-key.pem
+   ```
+
+2. Move the current key to the previous slot and deploy the new key:
+
+   ```sh
+   # Copy current key to previous slot
+   wrangler secret put OIDC_PROVIDER_KEY_PREVIOUS  # paste current key PEM
+   ```
+
+   Update `OIDC_PROVIDER_KID_PREVIOUS` in `wrangler.toml` to the current `OIDC_PROVIDER_KID` value, then set the new key ID and deploy:
+
+   ```sh
+   wrangler secret put OIDC_PROVIDER_KEY < new-key.pem
+   # Update OIDC_PROVIDER_KID in wrangler.toml to the new key ID
+   wrangler deploy
+   ```
+
+3. The JWKS endpoint now serves both keys. Wait for relying parties to refresh their JWKS cache.
+
+4. Remove the previous key:
+
+   ```sh
+   # Remove OIDC_PROVIDER_KID_PREVIOUS from wrangler.toml
+   wrangler secret delete OIDC_PROVIDER_KEY_PREVIOUS
+   wrangler deploy
+   ```
 
 ## Design Documents
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Set in `wrangler.toml` or via the Cloudflare dashboard:
 | `SOURCE_API_URL`             | `https://source.coop`       | Source Cooperative API base URL                                                                                                    |
 | `LOG_LEVEL`                  | `WARN`                      | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`)                                                                          |
 | `AUTH_ISSUER`                | `https://auth.source.coop`  | OIDC issuer trusted for `/.sts` token exchange                                                                                     |
-| `AUTH_AUDIENCE`              | —                           | OAuth client ID that `/.sts` subject tokens must be issued to (`aud` claim). Unset = tokens for any client of `AUTH_ISSUER` work |
+| `AUTH_AUDIENCE`              | —                           | OAuth client ID that `/.sts` subject tokens must be issued to (`aud` claim). Unset = `/.sts` token exchange is disabled (returns 501) |
 | `OIDC_PROVIDER_ISSUER`       | `https://data.source.coop`  | Issuer URL for minted JWTs and OIDC discovery                                                                                      |
 | `OIDC_PROVIDER_KID`          | `data-proxy-1`              | Key ID for the active signing key                                                                                                  |
 | `OIDC_PROVIDER_KID_PREVIOUS` | —                           | Key ID for the previous key (during rotation)                                                                                      |

--- a/README.md
+++ b/README.md
@@ -106,13 +106,15 @@ Write operations (`PUT`, `POST`, `DELETE`, `PATCH`) return `405 Method Not Allow
 
 Set in `wrangler.toml` or via the Cloudflare dashboard:
 
-| Variable                     | Default                    | Description                                               |
-| ---------------------------- | -------------------------- | --------------------------------------------------------- |
-| `SOURCE_API_URL`             | `https://source.coop`      | Source Cooperative API base URL                           |
-| `LOG_LEVEL`                  | `WARN`                     | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`) |
-| `OIDC_PROVIDER_ISSUER`       | `https://data.source.coop` | Issuer URL for minted JWTs and OIDC discovery             |
-| `OIDC_PROVIDER_KID`          | `data-proxy-1`             | Key ID for the active signing key                         |
-| `OIDC_PROVIDER_KID_PREVIOUS` | —                          | Key ID for the previous key (during rotation)             |
+| Variable                     | Default                     | Description                                                                                                                        |
+| ---------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `SOURCE_API_URL`             | `https://source.coop`       | Source Cooperative API base URL                                                                                                    |
+| `LOG_LEVEL`                  | `WARN`                      | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`)                                                                          |
+| `AUTH_ISSUER`                | `https://auth.source.coop`  | OIDC issuer trusted for `/.sts` token exchange                                                                                     |
+| `AUTH_AUDIENCE`              | —                           | OAuth client ID that `/.sts` subject tokens must be issued to (`aud` claim). Unset = tokens for any client of `AUTH_ISSUER` work |
+| `OIDC_PROVIDER_ISSUER`       | `https://data.source.coop`  | Issuer URL for minted JWTs and OIDC discovery                                                                                      |
+| `OIDC_PROVIDER_KID`          | `data-proxy-1`              | Key ID for the active signing key                                                                                                  |
+| `OIDC_PROVIDER_KID_PREVIOUS` | —                           | Key ID for the previous key (during rotation)                                                                                      |
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,18 @@ Set in `wrangler.toml` or via the Cloudflare dashboard:
 
 ### Secrets
 
-Set via `wrangler secret put`:
+**GitHub environment secrets are the source of truth.** The deploy workflow
+(`.github/workflows/deploy.yml`) re-uploads them via `wrangler secret bulk` on
+every deploy, so a value set directly with `wrangler secret put` is silently
+overwritten by the next deploy. Set them per GitHub environment (`preview`,
+`staging`, `production`) with `gh secret set <NAME> --env <environment>` or in
+the repository settings UI.
 
-| Secret                       | Description                                        |
-| ---------------------------- | -------------------------------------------------- |
-| `OIDC_PROVIDER_KEY`          | PEM-encoded PKCS#8 RSA private key for JWT signing |
-| `OIDC_PROVIDER_KEY_PREVIOUS` | Previous RSA key (optional, during rotation)       |
+| Secret                       | Description                                              |
+| ---------------------------- | -------------------------------------------------------- |
+| `OIDC_PROVIDER_KEY`          | PEM-encoded PKCS#8 RSA private key for JWT signing       |
+| `OIDC_PROVIDER_KEY_PREVIOUS` | Previous RSA key (optional, during rotation)             |
+| `SESSION_TOKEN_KEY`          | Base64-encoded 32-byte AES key sealing STS credentials   |
 
 ### Authentication Priority
 
@@ -142,12 +148,11 @@ These endpoints are only active when `OIDC_PROVIDER_KEY` is configured.
 
 ### Setup
 
-Generate an RSA key pair and deploy it:
+Generate an RSA key pair, store it as a GitHub environment secret, and deploy:
 
 ```sh
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out oidc-key.pem
-wrangler secret put OIDC_PROVIDER_KEY < oidc-key.pem
-wrangler deploy
+gh secret set OIDC_PROVIDER_KEY --env production < oidc-key.pem
 ```
 
 Verify the endpoints:
@@ -161,7 +166,11 @@ curl https://data.source.coop/.well-known/jwks.json
 
 The proxy supports zero-downtime key rotation by serving both active and previous public keys in the JWKS endpoint. Only the active key signs new tokens.
 
-**Rotation procedure:**
+Because CI re-uploads secrets from GitHub on every deploy, rotation happens
+through GitHub environment secrets and `wrangler.toml`, not `wrangler secret put`
+(which the next deploy would silently revert).
+
+**Rotation procedure** (repeat per environment — `preview`, `staging`, `production`):
 
 1. Generate a new RSA key with a new key ID:
 
@@ -169,30 +178,42 @@ The proxy supports zero-downtime key rotation by serving both active and previou
    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out new-key.pem
    ```
 
-2. Move the current key to the previous slot and deploy the new key:
+2. Move the current key to the previous slot and stage the new key:
 
    ```sh
-   # Copy current key to previous slot
-   wrangler secret put OIDC_PROVIDER_KEY_PREVIOUS  # paste current key PEM
+   # Copy the CURRENT key PEM into the previous slot
+   gh secret set OIDC_PROVIDER_KEY_PREVIOUS --env production < current-key.pem
+   gh secret set OIDC_PROVIDER_KEY --env production < new-key.pem
    ```
 
-   Update `OIDC_PROVIDER_KID_PREVIOUS` in `wrangler.toml` to the current `OIDC_PROVIDER_KID` value, then set the new key ID and deploy:
-
-   ```sh
-   wrangler secret put OIDC_PROVIDER_KEY < new-key.pem
-   # Update OIDC_PROVIDER_KID in wrangler.toml to the new key ID
-   wrangler deploy
-   ```
+   In `wrangler.toml`, set `OIDC_PROVIDER_KID_PREVIOUS` to the current
+   `OIDC_PROVIDER_KID` value and set `OIDC_PROVIDER_KID` to the new key ID.
+   Merge and let CI deploy.
 
 3. The JWKS endpoint now serves both keys. Wait for relying parties to refresh their JWKS cache.
 
 4. Remove the previous key:
 
    ```sh
-   # Remove OIDC_PROVIDER_KID_PREVIOUS from wrangler.toml
+   gh secret delete OIDC_PROVIDER_KEY_PREVIOUS --env production
+   # The worker-side copy isn't removed by CI, so delete it once manually:
    wrangler secret delete OIDC_PROVIDER_KEY_PREVIOUS
-   wrangler deploy
    ```
+
+   Remove `OIDC_PROVIDER_KID_PREVIOUS` from `wrangler.toml`, merge, and let CI deploy.
+
+### Rotating `SESSION_TOKEN_KEY`
+
+`SESSION_TOKEN_KEY` seals the temporary credentials issued by `/.sts`. There is
+no dual-key window: rotating it immediately invalidates every outstanding sealed
+credential (e.g. the frontend's `sc_proxy_creds` cookies), and affected clients
+must redo the token exchange. To rotate:
+
+```sh
+openssl rand -base64 32 | gh secret set SESSION_TOKEN_KEY --env production
+```
+
+The next deploy picks it up.
 
 ## Design Documents
 

--- a/README.md
+++ b/README.md
@@ -75,28 +75,28 @@ Client Request: GET /{account}/{product}/{key}
 
 ### Modules
 
-| Module | Purpose |
-|---|---|
-| `src/lib.rs` | Fetch handler, OIDC discovery endpoints, request routing, CORS |
-| `src/routing.rs` | Request classification and path rewriting |
-| `src/registry.rs` | Source Cooperative API client and backend resolution |
-| `src/cache.rs` | Cloudflare Cache API wrapper with per-datatype TTLs |
-| `src/pagination.rs` | S3-compatible pagination for prefix listings |
-| `src/analytics.rs` | Cloudflare Analytics Engine request logging |
-| `src/handlers.rs` | Custom route handlers (index, account listing) |
+| Module              | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `src/lib.rs`        | Fetch handler, OIDC discovery endpoints, request routing, CORS |
+| `src/routing.rs`    | Request classification and path rewriting                      |
+| `src/registry.rs`   | Source Cooperative API client and backend resolution           |
+| `src/cache.rs`      | Cloudflare Cache API wrapper with per-datatype TTLs            |
+| `src/pagination.rs` | S3-compatible pagination for prefix listings                   |
+| `src/analytics.rs`  | Cloudflare Analytics Engine request logging                    |
+| `src/handlers.rs`   | Custom route handlers (index, account listing)                 |
 
 ### Supported Operations
 
-| Operation | Description |
-|---|---|
-| `GET /` | Version info |
-| `GET /{account}?list-type=2` | List products for an account |
-| `GET /{account}/{product}?list-type=2` | List objects in a product (S3-compatible, with pagination) |
-| `GET /{account}/{product}/{key}` | Download an object (supports range requests) |
-| `HEAD /{account}/{product}/{key}` | Get object metadata |
-| `OPTIONS *` | CORS preflight |
-| `GET /.well-known/openid-configuration` | OIDC discovery document |
-| `GET /.well-known/jwks.json` | JSON Web Key Set for JWT verification |
+| Operation                               | Description                                                |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `GET /`                                 | Version info                                               |
+| `GET /{account}?list-type=2`            | List products for an account                               |
+| `GET /{account}/{product}?list-type=2`  | List objects in a product (S3-compatible, with pagination) |
+| `GET /{account}/{product}/{key}`        | Download an object (supports range requests)               |
+| `HEAD /{account}/{product}/{key}`       | Get object metadata                                        |
+| `OPTIONS *`                             | CORS preflight                                             |
+| `GET /.well-known/openid-configuration` | OIDC discovery document                                    |
+| `GET /.well-known/jwks.json`            | JSON Web Key Set for JWT verification                      |
 
 Write operations (`PUT`, `POST`, `DELETE`, `PATCH`) return `405 Method Not Allowed`.
 
@@ -106,31 +106,26 @@ Write operations (`PUT`, `POST`, `DELETE`, `PATCH`) return `405 Method Not Allow
 
 Set in `wrangler.toml` or via the Cloudflare dashboard:
 
-| Variable | Default | Description |
-|---|---|---|
-| `SOURCE_API_URL` | `https://source.coop` | Source Cooperative API base URL |
-| `LOG_LEVEL` | `WARN` | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`) |
-| `OIDC_PROVIDER_ISSUER` | `https://data.source.coop` | Issuer URL for minted JWTs and OIDC discovery |
-| `OIDC_PROVIDER_KID` | `data-proxy-1` | Key ID for the active signing key |
-| `OIDC_PROVIDER_KID_PREVIOUS` | — | Key ID for the previous key (during rotation) |
+| Variable                     | Default                    | Description                                               |
+| ---------------------------- | -------------------------- | --------------------------------------------------------- |
+| `SOURCE_API_URL`             | `https://source.coop`      | Source Cooperative API base URL                           |
+| `LOG_LEVEL`                  | `WARN`                     | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`) |
+| `OIDC_PROVIDER_ISSUER`       | `https://data.source.coop` | Issuer URL for minted JWTs and OIDC discovery             |
+| `OIDC_PROVIDER_KID`          | `data-proxy-1`             | Key ID for the active signing key                         |
+| `OIDC_PROVIDER_KID_PREVIOUS` | —                          | Key ID for the previous key (during rotation)             |
 
 ### Secrets
 
 Set via `wrangler secret put`:
 
-| Secret | Description |
-|---|---|
-| `SOURCE_API_SECRET` | Static API token (legacy fallback, used when OIDC is not configured) |
-| `OIDC_PROVIDER_KEY` | PEM-encoded PKCS#8 RSA private key for JWT signing |
-| `OIDC_PROVIDER_KEY_PREVIOUS` | Previous RSA key (optional, during rotation) |
+| Secret                       | Description                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `OIDC_PROVIDER_KEY`          | PEM-encoded PKCS#8 RSA private key for JWT signing |
+| `OIDC_PROVIDER_KEY_PREVIOUS` | Previous RSA key (optional, during rotation)       |
 
 ### Authentication Priority
 
-The proxy authenticates to the Source Cooperative API in this order:
-
-1. **OIDC JWT** — if `OIDC_PROVIDER_KEY` is set, the proxy mints a short-lived JWT (60s TTL) signed with its RSA key and sends it as a `Bearer` token
-2. **Static secret** — if only `SOURCE_API_SECRET` is set, it is sent as the `Authorization` header
-3. **None** — if neither is configured, requests are unauthenticated
+The proxy authenticates to the Source Cooperative API via minting short-lived JWT (60s TTL) signed with its RSA key and sending it as a `Bearer` token
 
 ## OIDC Provider
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,29 @@
+use multistore_oidc_provider::jwt::JwtSigner;
+
+/// How the proxy authenticates to the Source Cooperative API.
+#[derive(Clone)]
+pub(crate) struct ApiAuth {
+    signer: Box<JwtSigner>,
+    issuer: String,
+    audience: String,
+}
+
+impl ApiAuth {
+    pub fn new(signer: JwtSigner, issuer: String, audience: String) -> Self {
+        Self {
+            signer: Box::new(signer),
+            issuer,
+            audience,
+        }
+    }
+
+    pub fn authorization_header(&self, subject: &str) -> Option<String> {
+        match self.signer.sign(subject, &self.issuer, &self.audience, &[]) {
+            Ok(token) => Some(format!("Bearer {}", token)),
+            Err(e) => {
+                tracing::error!("failed to sign API auth JWT: {}", e);
+                None
+            }
+        }
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,6 +17,14 @@ impl ApiAuth {
         }
     }
 
+    /// Build the `Authorization` header value for an API request on behalf of
+    /// `subject`.
+    ///
+    /// Returns `None` if signing fails. The signing key is parsed and validated
+    /// once at startup (`JwtSigner::from_pem`, which panics on a bad key), so a
+    /// runtime failure here is very unlikely. When it does happen the error is
+    /// logged and the caller falls through to an unauthenticated request, which
+    /// the API surfaces as `AccessDenied` (403) rather than a 500.
     pub fn authorization_header(&self, subject: &str) -> Option<String> {
         match self.signer.sign(subject, &self.issuer, &self.audience, &[]) {
             Ok(token) => Some(format!("Bearer {}", token)),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -30,8 +30,9 @@ pub async fn get_or_fetch_product(
     subject: Option<&str>,
 ) -> Result<SourceProduct, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}/{}", api_base_url, account, product);
+    let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
-        &api_url,
+        &cache_key,
         &api_url,
         PRODUCT_CACHE_SECS,
         api_auth,
@@ -49,8 +50,9 @@ pub async fn get_or_fetch_data_connections(
     subject: Option<&str>,
 ) -> Result<Vec<DataConnection>, ProxyError> {
     let api_url = format!("{}/api/v1/data-connections", api_base_url);
+    let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
-        &api_url,
+        &cache_key,
         &api_url,
         DATA_CONNECTIONS_CACHE_SECS,
         api_auth,
@@ -69,8 +71,9 @@ pub async fn get_or_fetch_product_list(
     subject: Option<&str>,
 ) -> Result<SourceProductList, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}", api_base_url, account);
+    let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
-        &api_url,
+        &cache_key,
         &api_url,
         PRODUCT_LIST_CACHE_SECS,
         api_auth,
@@ -80,7 +83,17 @@ pub async fn get_or_fetch_product_list(
     .await
 }
 
-// ── Internal helper ────────────────────────────────────────────────
+// ── Internal helpers ──────────────────────────────────────────────
+
+/// Build a cache key that includes the caller's identity so that
+/// responses for different users (or anonymous vs authenticated) are
+/// cached separately.
+fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
+    match subject {
+        Some(subj) => format!("{}?subject={}", api_url, subj),
+        None => api_url.to_string(),
+    }
+}
 
 /// Generic cache-or-fetch: check the Cache API, return cached JSON on hit,
 /// otherwise fetch from `api_url`, store in cache with the given TTL, and

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -89,6 +89,12 @@ pub async fn get_or_fetch_product_list(
 /// responses for different users (or anonymous vs authenticated) are
 /// cached separately.
 fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
+    // Appending `?subject=` assumes the URL has no query string of its own —
+    // a `?` already present would silently produce a malformed key.
+    debug_assert!(
+        !api_url.contains('?'),
+        "cache_key_with_subject requires a query-free api_url, got {api_url}"
+    );
     match subject {
         // Hex-encode the subject so the cache key is always a well-formed URL.
         // Principal names can contain spaces, `&`, `#`, or non-ASCII, any of

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,24 +25,17 @@ pub async fn get_or_fetch_product(
     api_base_url: &str,
     account: &str,
     product: &str,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<SourceProduct, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}/{}", api_base_url, account, product);
-    cached_fetch(
-        &api_url,
-        &api_url,
-        PRODUCT_CACHE_SECS,
-        api_secret,
-        request_id,
-    )
-    .await
+    cached_fetch(&api_url, &api_url, PRODUCT_CACHE_SECS, api_auth, request_id).await
 }
 
 /// Fetch all data connections, cached for `DATA_CONNECTIONS_CACHE_SECS`.
 pub async fn get_or_fetch_data_connections(
     api_base_url: &str,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<Vec<DataConnection>, ProxyError> {
     let api_url = format!("{}/api/v1/data-connections", api_base_url);
@@ -50,7 +43,7 @@ pub async fn get_or_fetch_data_connections(
         &api_url,
         &api_url,
         DATA_CONNECTIONS_CACHE_SECS,
-        api_secret,
+        api_auth,
         request_id,
     )
     .await
@@ -60,7 +53,7 @@ pub async fn get_or_fetch_data_connections(
 pub async fn get_or_fetch_product_list(
     api_base_url: &str,
     account: &str,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<SourceProductList, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}", api_base_url, account);
@@ -68,7 +61,7 @@ pub async fn get_or_fetch_product_list(
         &api_url,
         &api_url,
         PRODUCT_LIST_CACHE_SECS,
-        api_secret,
+        api_auth,
         request_id,
     )
     .await
@@ -83,7 +76,7 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     cache_key: &str,
     api_url: &str,
     ttl_secs: u32,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<T, ProxyError> {
     let span = tracing::info_span!(
@@ -117,9 +110,9 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     init.set_method("GET");
     let req_headers = web_sys::Headers::new()
         .map_err(|e| ProxyError::Internal(format!("headers build failed: {:?}", e)))?;
-    if let Some(secret) = api_secret {
+    if let Some(auth_value) = api_auth.authorization_header() {
         req_headers
-            .set("Authorization", secret)
+            .set("Authorization", &auth_value)
             .map_err(|e| ProxyError::Internal(format!("header set failed: {:?}", e)))?;
     }
     if !request_id.is_empty() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -167,14 +167,19 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
 
     let status = resp.status_code();
     span.record("api_status", status);
-    if status == 404 {
-        return Err(ProxyError::BucketNotFound("not found".into()));
-    }
-    if status != 200 {
-        return Err(ProxyError::Internal(format!(
-            "API returned {} for {}",
-            status, api_url
-        )));
+    match status {
+        200 => {}
+        404 => return Err(ProxyError::BucketNotFound("not found".into())),
+        // Upstream rejected our credentials (or the resource requires auth we
+        // don't have). Surface this as an S3 permissions error rather than a
+        // server fault.
+        401 | 403 => return Err(ProxyError::AccessDenied),
+        _ => {
+            return Err(ProxyError::Internal(format!(
+                "API returned {} for {}",
+                status, api_url
+            )))
+        }
     }
 
     let text = resp

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -90,7 +90,14 @@ pub async fn get_or_fetch_product_list(
 /// cached separately.
 fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
     match subject {
-        Some(subj) => format!("{}?subject={}", api_url, subj),
+        // Hex-encode the subject so the cache key is always a well-formed URL.
+        // Principal names can contain spaces, `&`, `#`, or non-ASCII, any of
+        // which would otherwise corrupt the key or collide distinct subjects.
+        // Hex is injective and URL-safe, so each subject maps to a unique key.
+        Some(subj) => {
+            let encoded: String = subj.bytes().map(|b| format!("{:02x}", b)).collect();
+            format!("{}?subject={}", api_url, encoded)
+        }
         None => api_url.to_string(),
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,9 +27,18 @@ pub async fn get_or_fetch_product(
     product: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<SourceProduct, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}/{}", api_base_url, account, product);
-    cached_fetch(&api_url, &api_url, PRODUCT_CACHE_SECS, api_auth, request_id).await
+    cached_fetch(
+        &api_url,
+        &api_url,
+        PRODUCT_CACHE_SECS,
+        api_auth,
+        request_id,
+        subject,
+    )
+    .await
 }
 
 /// Fetch all data connections, cached for `DATA_CONNECTIONS_CACHE_SECS`.
@@ -37,6 +46,7 @@ pub async fn get_or_fetch_data_connections(
     api_base_url: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<Vec<DataConnection>, ProxyError> {
     let api_url = format!("{}/api/v1/data-connections", api_base_url);
     cached_fetch(
@@ -45,6 +55,7 @@ pub async fn get_or_fetch_data_connections(
         DATA_CONNECTIONS_CACHE_SECS,
         api_auth,
         request_id,
+        subject,
     )
     .await
 }
@@ -55,6 +66,7 @@ pub async fn get_or_fetch_product_list(
     account: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<SourceProductList, ProxyError> {
     let api_url = format!("{}/api/v1/products/{}", api_base_url, account);
     cached_fetch(
@@ -63,6 +75,7 @@ pub async fn get_or_fetch_product_list(
         PRODUCT_LIST_CACHE_SECS,
         api_auth,
         request_id,
+        subject,
     )
     .await
 }
@@ -78,6 +91,7 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     ttl_secs: u32,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<T, ProxyError> {
     let span = tracing::info_span!(
         "cached_fetch",
@@ -110,10 +124,14 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     init.set_method("GET");
     let req_headers = web_sys::Headers::new()
         .map_err(|e| ProxyError::Internal(format!("headers build failed: {:?}", e)))?;
-    if let Some(auth_value) = api_auth.authorization_header() {
-        req_headers
-            .set("Authorization", &auth_value)
-            .map_err(|e| ProxyError::Internal(format!("header set failed: {:?}", e)))?;
+    // Only authenticate to the API when we have an identified caller.
+    // Anonymous proxy requests hit the API without credentials.
+    if let Some(subj) = subject {
+        if let Some(auth_value) = api_auth.authorization_header(subj) {
+            req_headers
+                .set("Authorization", &auth_value)
+                .map_err(|e| ProxyError::Internal(format!("header set failed: {:?}", e)))?;
+        }
     }
     if !request_id.is_empty() {
         let _ = req_headers.set("x-request-id", request_id);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,6 +5,19 @@
 
 use crate::registry::{DataConnection, SourceProduct, SourceProductList};
 use multistore::error::ProxyError;
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+/// Percent-encode set for a single URL path segment: everything except the
+/// RFC 3986 unreserved characters (`A-Z a-z 0-9 - . _ ~`). Ordinary
+/// account/product slugs pass through byte-identical, while a decoded `?`,
+/// `#`, `&`, `/`, or space — which the request path is decoded into before
+/// segmentation — is encoded so it cannot inject into the upstream API URL or
+/// forge a colliding cache key.
+const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
 
 // ── Per-datatype TTLs ──────────────────────────────────────────────
 // Tune these to control how long each API response is cached at the edge.
@@ -29,7 +42,12 @@ pub async fn get_or_fetch_product(
     request_id: &str,
     subject: Option<&str>,
 ) -> Result<SourceProduct, ProxyError> {
-    let api_url = format!("{}/api/v1/products/{}/{}", api_base_url, account, product);
+    let api_url = format!(
+        "{}/api/v1/products/{}/{}",
+        api_base_url,
+        utf8_percent_encode(account, PATH_SEGMENT),
+        utf8_percent_encode(product, PATH_SEGMENT),
+    );
     let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
         &cache_key,
@@ -70,7 +88,11 @@ pub async fn get_or_fetch_product_list(
     request_id: &str,
     subject: Option<&str>,
 ) -> Result<SourceProductList, ProxyError> {
-    let api_url = format!("{}/api/v1/products/{}", api_base_url, account);
+    let api_url = format!(
+        "{}/api/v1/products/{}",
+        api_base_url,
+        utf8_percent_encode(account, PATH_SEGMENT),
+    );
     let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
         &cache_key,
@@ -89,12 +111,6 @@ pub async fn get_or_fetch_product_list(
 /// responses for different users (or anonymous vs authenticated) are
 /// cached separately.
 fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
-    // Appending `?subject=` assumes the URL has no query string of its own —
-    // a `?` already present would silently produce a malformed key.
-    debug_assert!(
-        !api_url.contains('?'),
-        "cache_key_with_subject requires a query-free api_url, got {api_url}"
-    );
     match subject {
         // Hex-encode the subject so the cache key is always a well-formed URL.
         // Principal names can contain spaces, `&`, `#`, or non-ASCII, any of
@@ -102,7 +118,12 @@ fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
         // Hex is injective and URL-safe, so each subject maps to a unique key.
         Some(subj) => {
             let encoded: String = subj.bytes().map(|b| format!("{:02x}", b)).collect();
-            format!("{}?subject={}", api_url, encoded)
+            // Pick the query separator defensively. Callers pass query-free
+            // URLs today (path segments are percent-encoded above), but a stray
+            // `?` must never silently merge into an existing query and forge a
+            // cache key that collides with another caller's.
+            let sep = if api_url.contains('?') { '&' } else { '?' };
+            format!("{api_url}{sep}subject={encoded}")
         }
         None => api_url.to_string(),
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,7 +108,8 @@ pub struct AppConfig {
     /// OIDC issuer URL for the Source Cooperative auth provider (e.g. `https://auth.source.coop`).
     pub auth_issuer: String,
     /// OAuth client ID that subject tokens presented to `/.sts` must be
-    /// issued to (the `aud` claim). `None` disables the audience check.
+    /// issued to (the `aud` claim). Required; `None` disables the `/.sts`
+    /// endpoint entirely (returns 501) rather than accepting any audience.
     pub auth_audience: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,65 @@
+use multistore_oidc_provider::jwt::JwtSigner;
+use worker::Env;
+
+pub fn load_config(env: &Env) -> AppConfig {
+    let api_base_url = env
+        .var("SOURCE_API_URL")
+        .map(|v| v.to_string())
+        .expect("SOURCE_API_URL must be set");
+    let oidc = {
+        let pem = env
+            .secret("OIDC_PROVIDER_KEY")
+            .expect("OIDC_PROVIDER_KEY must be set")
+            .to_string();
+        let kid = env
+            .var("OIDC_PROVIDER_KID")
+            .expect("OIDC_PROVIDER_KID must be set")
+            .to_string();
+        let issuer = env
+            .var("OIDC_PROVIDER_ISSUER")
+            .expect("OIDC_PROVIDER_ISSUER must be set")
+            .to_string();
+
+        let signer = JwtSigner::from_pem(&pem, kid, 60)
+            .expect("failed to create JwtSigner from OIDC_PROVIDER_KEY");
+
+        // Optional previous key for rotation
+        let previous_signer = {
+            let prev_pem = env
+                .secret("OIDC_PROVIDER_KEY_PREVIOUS")
+                .expect("OIDC_PROVIDER_KEY_PREVIOUS must be set")
+                .to_string();
+            let prev_kid = env
+                .var("OIDC_PROVIDER_KID_PREVIOUS")
+                .expect("OIDC_PROVIDER_KID_PREVIOUS must be set")
+                .to_string();
+            match JwtSigner::from_pem(&prev_pem, prev_kid, 60) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    tracing::warn!("failed to load previous OIDC key: {}", e);
+                    None
+                }
+            }
+        };
+
+        OidcConfig {
+            signer,
+            issuer,
+            previous_signer,
+        }
+    };
+
+    AppConfig { api_base_url, oidc }
+}
+
+pub struct AppConfig {
+    pub api_base_url: String,
+    pub oidc: OidcConfig,
+}
+
+pub struct OidcConfig {
+    pub issuer: String,
+    pub signer: JwtSigner,
+    /// Previous key for rotation — served in JWKS but not used for signing.
+    pub previous_signer: Option<JwtSigner>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,11 +69,26 @@ fn build_config(env: &Env) -> AppConfig {
         .map(|v| v.to_string())
         .expect("AUTH_ISSUER must be set");
 
+    let auth_audience = env
+        .var("AUTH_AUDIENCE")
+        .map(|v| v.to_string())
+        .ok()
+        .filter(|s| !s.is_empty());
+    if auth_audience.is_none() {
+        // Without an audience restriction, an ID token minted for ANY OAuth
+        // client registered with AUTH_ISSUER can be exchanged at /.sts.
+        tracing::warn!(
+            "AUTH_AUDIENCE not set: /.sts will accept ID tokens issued to any \
+             OAuth client of AUTH_ISSUER, not just the Source Cooperative web flow"
+        );
+    }
+
     AppConfig {
         api_base_url,
         oidc,
         session_token_key,
         auth_issuer,
+        auth_audience,
     }
 }
 
@@ -84,6 +99,9 @@ pub struct AppConfig {
     pub session_token_key: TokenKey,
     /// OIDC issuer URL for the Source Cooperative auth provider (e.g. `https://auth.source.coop`).
     pub auth_issuer: String,
+    /// OAuth client ID that subject tokens presented to `/.sts` must be
+    /// issued to (the `aud` claim). `None` disables the audience check.
+    pub auth_audience: Option<String>,
 }
 
 pub struct OidcConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,12 +75,10 @@ fn build_config(env: &Env) -> AppConfig {
         .ok()
         .filter(|s| !s.is_empty());
     if auth_audience.is_none() {
-        // Without an audience restriction, an ID token minted for ANY OAuth
-        // client registered with AUTH_ISSUER can be exchanged at /.sts.
-        tracing::warn!(
-            "AUTH_AUDIENCE not set: /.sts will accept ID tokens issued to any \
-             OAuth client of AUTH_ISSUER, not just the Source Cooperative web flow"
-        );
+        // Fail closed: without an audience restriction, an ID token minted for
+        // ANY OAuth client of AUTH_ISSUER could be exchanged for a user's
+        // credentials, so /.sts is disabled entirely (returns 501) until set.
+        tracing::warn!("AUTH_AUDIENCE not set: /.sts token exchange is disabled (returns 501)");
     }
 
     AppConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use multistore_oidc_provider::jwt::JwtSigner;
+use multistore_sts::sealed_token::TokenKey;
 use worker::Env;
 
 pub fn load_config(env: &Env) -> AppConfig {
@@ -45,12 +46,33 @@ pub fn load_config(env: &Env) -> AppConfig {
         }
     };
 
-    AppConfig { api_base_url, oidc }
+    let session_token_key = TokenKey::from_base64(
+        &env.secret("SESSION_TOKEN_KEY")
+            .expect("SESSION_TOKEN_KEY must be set")
+            .to_string(),
+    )
+    .expect("SESSION_TOKEN_KEY must be valid base64-encoded 32-byte key");
+
+    let auth_issuer = env
+        .var("AUTH_ISSUER")
+        .map(|v| v.to_string())
+        .expect("AUTH_ISSUER must be set");
+
+    AppConfig {
+        api_base_url,
+        oidc,
+        session_token_key,
+        auth_issuer,
+    }
 }
 
 pub struct AppConfig {
     pub api_base_url: String,
     pub oidc: OidcConfig,
+    /// AES key for sealing/unsealing STS session tokens.
+    pub session_token_key: TokenKey,
+    /// OIDC issuer URL for the Source Cooperative auth provider (e.g. `https://auth.source.coop`).
+    pub auth_issuer: String,
 }
 
 pub struct OidcConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,23 +24,19 @@ pub fn load_config(env: &Env) -> AppConfig {
             .expect("failed to create JwtSigner from OIDC_PROVIDER_KEY");
 
         // Optional previous key for rotation
-        let previous_signer = {
-            let prev_pem = env
-                .secret("OIDC_PROVIDER_KEY_PREVIOUS")
-                .expect("OIDC_PROVIDER_KEY_PREVIOUS must be set")
-                .to_string();
-            let prev_kid = env
-                .var("OIDC_PROVIDER_KID_PREVIOUS")
-                .expect("OIDC_PROVIDER_KID_PREVIOUS must be set")
-                .to_string();
-            match JwtSigner::from_pem(&prev_pem, prev_kid, 60) {
-                Ok(s) => Some(s),
-                Err(e) => {
-                    tracing::warn!("failed to load previous OIDC key: {}", e);
-                    None
+        let previous_signer = env
+            .secret("OIDC_PROVIDER_KEY_PREVIOUS")
+            .ok()
+            .and_then(|prev_pem| {
+                let prev_kid = env.var("OIDC_PROVIDER_KID_PREVIOUS").ok()?.to_string();
+                match JwtSigner::from_pem(&prev_pem.to_string(), prev_kid, 60) {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        tracing::warn!("failed to load previous OIDC key: {}", e);
+                        None
+                    }
                 }
-            }
-        };
+            });
 
         OidcConfig {
             signer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,17 @@ fn build_config(env: &Env) -> AppConfig {
             .secret("OIDC_PROVIDER_KEY_PREVIOUS")
             .ok()
             .and_then(|prev_pem| {
-                let prev_kid = env.var("OIDC_PROVIDER_KID_PREVIOUS").ok()?.to_string();
+                let prev_kid = match env.var("OIDC_PROVIDER_KID_PREVIOUS") {
+                    Ok(k) => k.to_string(),
+                    Err(_) => {
+                        tracing::warn!(
+                            "OIDC_PROVIDER_KEY_PREVIOUS is set but OIDC_PROVIDER_KID_PREVIOUS \
+                             is missing -- previous key omitted from JWKS; set \
+                             OIDC_PROVIDER_KID_PREVIOUS to complete rotation"
+                        );
+                        return None;
+                    }
+                };
                 match JwtSigner::from_pem(&prev_pem.to_string(), prev_kid, 60) {
                     Ok(s) => Some(s),
                     Err(e) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,19 @@
+use std::sync::OnceLock;
+
 use multistore_oidc_provider::jwt::JwtSigner;
 use multistore_sts::sealed_token::TokenKey;
 use worker::Env;
 
-pub fn load_config(env: &Env) -> AppConfig {
+static CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+/// Return the process-wide config, parsing env/secrets the first time it's
+/// called. Subsequent calls within the same isolate are free — in particular,
+/// the RSA OIDC signing keys are parsed from PEM exactly once.
+pub fn load_config(env: &Env) -> &'static AppConfig {
+    CONFIG.get_or_init(|| build_config(env))
+}
+
+fn build_config(env: &Env) -> AppConfig {
     let api_base_url = env
         .var("SOURCE_API_URL")
         .map(|v| v.to_string())

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,7 +4,7 @@
 //! custom endpoints are checked before the S3 proxy pipeline runs.
 
 use multistore::api::list::parse_list_query_params;
-use multistore::api::response::{ListBucketResult, ListCommonPrefix};
+use multistore::api::response::{ErrorResponse, ListBucketResult, ListCommonPrefix};
 use multistore::route_handler::{ProxyResult, RequestInfo, RouteHandler, RouteHandlerFuture};
 
 use crate::pagination::paginate_prefixes;
@@ -110,13 +110,11 @@ impl RouteHandler for AccountListHandler {
                 }
                 Err(e) => {
                     tracing::error!("AccountList({}) error: {:?}", account, e);
-                    let err = multistore::api::response::ErrorResponse {
-                        code: "BadGateway".to_string(),
-                        message: "Failed to list products from upstream API".to_string(),
-                        resource: String::new(),
-                        request_id: self.registry.request_id.clone(),
-                    };
-                    Some(ProxyResult::xml(502, err.to_xml()))
+                    // Let the ProxyError variant drive the S3 error code and
+                    // HTTP status (e.g. AccessDenied → 403, Internal → 500).
+                    let body =
+                        ErrorResponse::from_proxy_error(&e, "", &self.registry.request_id, false);
+                    Some(ProxyResult::xml(e.status_code(), body.to_xml()))
                 }
             }
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,11 +119,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         None,
     )
     .with_router(router)
-    .with_debug_errors(max_level >= tracing::Level::DEBUG);
-
-    // Register the token key as credential resolver so sealed STS tokens
-    // can be verified on subsequent authenticated requests.
-    let gateway = gateway.with_credential_resolver(config.session_token_key.clone());
+    .with_debug_errors(max_level >= tracing::Level::DEBUG)
+    .with_credential_resolver(config.session_token_key.clone());
 
     // ── Dispatch through gateway ──────────────────────────────────
     let span = tracing::info_span!("request", %request_id, %method, %path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,14 +63,18 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
     let request_id = extract_request_id(&parts.headers);
 
-    // ── Short-circuit: OPTIONS preflight ────────────────────────────
-    if parts.method == http::Method::OPTIONS {
-        return Ok(add_cors(empty_response(204)));
-    }
-
     // Special endpoints (OIDC discovery, STS token exchange) manage their own
     // methods and bypass the S3 object/bucket path mapping below.
     let is_special_path = parts.path.starts_with("/.well-known/") || parts.path == "/.sts";
+
+    // POST is only meaningful for STS token exchange; everything else is
+    // read-only, so don't advertise write methods globally via CORS.
+    let cors_allow_post = parts.path == "/.sts";
+
+    // ── Short-circuit: OPTIONS preflight ────────────────────────────
+    if parts.method == http::Method::OPTIONS {
+        return Ok(add_cors(empty_response(204), cors_allow_post));
+    }
 
     // ── Short-circuit: write methods ────────────────────────────────
     // The proxy is read-only for object/bucket paths, so writes get an
@@ -85,6 +89,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         };
         return Ok(add_cors(
             GatewayResponse::Response(ProxyResult::xml(405, resp.to_xml())).into_web_sys(),
+            cors_allow_post,
         ));
     }
 
@@ -209,7 +214,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         }
     }
 
-    let response = add_cors(response);
+    let response = add_cors(response, cors_allow_post);
     if !request_id.is_empty() {
         let _ = response.headers().set("x-request-id", &request_id);
     }
@@ -396,14 +401,17 @@ fn empty_response(status: u16) -> web_sys::Response {
 
 // ── CORS ────────────────────────────────────────────────────────────
 
-fn add_cors(resp: web_sys::Response) -> web_sys::Response {
+fn add_cors(resp: web_sys::Response, allow_post: bool) -> web_sys::Response {
     let h = resp.headers();
+    // The proxy is read-only; POST is advertised only on the STS endpoint.
+    let methods = if allow_post {
+        "GET, HEAD, POST, OPTIONS"
+    } else {
+        "GET, HEAD, OPTIONS"
+    };
     for (name, value) in [
         ("access-control-allow-origin", "*"),
-        (
-            "access-control-allow-methods",
-            "GET, HEAD, PUT, POST, DELETE, OPTIONS",
-        ),
+        ("access-control-allow-methods", methods),
         ("access-control-allow-headers", "*"),
         ("access-control-expose-headers", "*"),
     ] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod analytics;
 mod cache;
+mod config;
 mod handlers;
 mod pagination;
 mod registry;
@@ -14,11 +15,13 @@ use multistore_cf_workers::{
     collect_js_body, error_response, headermap_from_js, response_from_gateway, xml_response,
     JsBody, NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
 };
-use multistore_oidc_provider::discovery::openid_configuration_json;
 use multistore_oidc_provider::jwt::JwtSigner;
+use multistore_oidc_provider::route_handler::OidcRouterExt;
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use registry::SourceCoopRegistry;
 use worker::{event, Context, Env, Result};
+
+use crate::config::load_config;
 
 /// Separator used to join account + product into a single internal bucket name.
 pub(crate) const BUCKET_SEPARATOR: &str = ":";
@@ -54,21 +57,6 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         return Ok(add_cors(error_response(204, "")));
     }
 
-    // ── Short-circuit: OIDC discovery endpoints ─────────────────
-    if let Some(ref oidc) = config.oidc {
-        if path == "/.well-known/openid-configuration" && method == http::Method::GET {
-            let json = openid_configuration_json(
-                &oidc.issuer,
-                &format!("{}/.well-known/jwks.json", oidc.issuer),
-            );
-            return Ok(add_cors(json_response(200, &json)));
-        }
-        if path == "/.well-known/jwks.json" && method == http::Method::GET {
-            let json = build_jwks_json(oidc);
-            return Ok(add_cors(json_response(200, &json)));
-        }
-    }
-
     // ── Short-circuit: write methods ───────────────────────────────
     if is_write_method(&method) {
         let resp = ErrorResponse {
@@ -91,14 +79,10 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let (rewritten_path, rewritten_query) = mapping.rewrite_request(&path, query.as_deref());
 
     // ── Build API auth ─────────────────────────────────────────────
-    let api_auth = match (&config.oidc, &config.api_secret) {
-        (Some(oidc), _) => ApiAuth::Oidc {
-            signer: Box::new(oidc.signer.clone()),
-            issuer: oidc.issuer.clone(),
-            audience: config.api_base_url.clone(),
-        },
-        (None, Some(secret)) => ApiAuth::Secret(secret.clone()),
-        (None, None) => ApiAuth::None,
+    let api_auth = ApiAuth {
+        signer: Box::new(config.oidc.signer.clone()),
+        issuer: config.oidc.issuer.clone(),
+        audience: config.api_base_url.clone(),
     };
 
     // ── Build gateway with route handlers ──────────────────────────
@@ -116,6 +100,13 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     )
     .with_router(
         Router::new()
+            // OIDC discovery routes (served from this proxy)
+            .with_oidc_discovery(
+                config.oidc.issuer.clone(),
+                std::iter::once(config.oidc.signer.clone())
+                    .chain(config.oidc.previous_signer.clone())
+                    .collect(),
+            )
             .route("/", IndexHandler)
             .route("/{bucket}", AccountListHandler::new(registry, &mapping)),
     )
@@ -172,101 +163,27 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-struct AppConfig {
-    api_base_url: String,
-    api_secret: Option<String>,
-    oidc: Option<OidcConfig>,
-}
-
-struct OidcConfig {
-    signer: JwtSigner,
-    issuer: String,
-    /// Previous key for rotation — served in JWKS but not used for signing.
-    previous_signer: Option<JwtSigner>,
-}
-
 /// How the proxy authenticates to the Source Cooperative API.
 #[derive(Clone)]
-pub(crate) enum ApiAuth {
-    /// OIDC JWT bearer token.
-    Oidc {
-        signer: Box<JwtSigner>,
-        issuer: String,
-        audience: String,
-    },
-    /// Static shared secret (legacy).
-    Secret(String),
-    /// No authentication.
-    None,
+pub(crate) struct ApiAuth {
+    signer: Box<JwtSigner>,
+    issuer: String,
+    audience: String,
 }
 
 impl ApiAuth {
-    /// Generate an Authorization header value.
     fn authorization_header(&self) -> Option<String> {
-        match self {
-            ApiAuth::Oidc {
-                signer,
-                issuer,
-                audience,
-            } => match signer.sign("data-proxy", issuer, audience, &[]) {
-                Ok(token) => Some(format!("Bearer {}", token)),
-                Err(e) => {
-                    tracing::error!("failed to sign API auth JWT: {}", e);
-                    None
-                }
-            },
-            ApiAuth::Secret(secret) => Some(secret.clone()),
-            ApiAuth::None => None,
-        }
-    }
-}
-
-fn load_config(env: &Env) -> AppConfig {
-    let api_base_url = env
-        .var("SOURCE_API_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|_| "https://source.coop".to_string());
-    let api_secret = env.secret("SOURCE_API_SECRET").map(|v| v.to_string()).ok();
-    let oidc = load_oidc_config(env);
-
-    AppConfig {
-        api_base_url,
-        api_secret,
-        oidc,
-    }
-}
-
-fn load_oidc_config(env: &Env) -> Option<OidcConfig> {
-    let pem = env.secret("OIDC_PROVIDER_KEY").ok()?.to_string();
-    let kid = env.var("OIDC_PROVIDER_KID").ok()?.to_string();
-    let issuer = env.var("OIDC_PROVIDER_ISSUER").ok()?.to_string();
-
-    let signer = match JwtSigner::from_pem(&pem, kid, 60) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("failed to load OIDC provider key: {}", e);
-            return None;
-        }
-    };
-
-    // Optional previous key for rotation
-    let previous_signer = (|| {
-        let prev_pem = env.secret("OIDC_PROVIDER_KEY_PREVIOUS").ok()?.to_string();
-        let prev_kid = env.var("OIDC_PROVIDER_KID_PREVIOUS").ok()?.to_string();
-        match JwtSigner::from_pem(&prev_pem, prev_kid, 60) {
-            Ok(s) => Some(s),
+        match self
+            .signer
+            .sign("data-proxy", &self.issuer, &self.audience, &[])
+        {
+            Ok(token) => Some(format!("Bearer {}", token)),
             Err(e) => {
-                tracing::warn!("failed to load previous OIDC key: {}", e);
+                tracing::error!("failed to sign API auth JWT: {}", e);
                 None
             }
         }
-    })();
-
-    Some(OidcConfig {
-        signer,
-        issuer,
-        previous_signer,
-    })
+    }
 }
 
 fn init_tracing(env: &Env) -> tracing::Level {
@@ -435,53 +352,6 @@ fn maybe_broadcast_location(ctx: &Context, env: &Env, event: LocationEvent) {
             .fetch("https://public-log-stream/location", Some(init))
             .await;
     });
-}
-
-// ── OIDC helpers ────────────────────────────────────────────────────
-
-/// Build JWKS JSON containing the active key and optionally the previous key.
-fn build_jwks_json(oidc: &OidcConfig) -> String {
-    use multistore_oidc_provider::jwks::jwks_json as single_jwks_json;
-
-    if oidc.previous_signer.is_none() {
-        return single_jwks_json(oidc.signer.public_key(), oidc.signer.kid());
-    }
-
-    // Parse both single-key JWKS and merge their "keys" arrays
-    let active: serde_json::Value = serde_json::from_str(&single_jwks_json(
-        oidc.signer.public_key(),
-        oidc.signer.kid(),
-    ))
-    .expect("active JWKS from library should be valid JSON");
-    let previous_signer = oidc.previous_signer.as_ref().expect("checked above");
-    let previous: serde_json::Value = serde_json::from_str(&single_jwks_json(
-        previous_signer.public_key(),
-        previous_signer.kid(),
-    ))
-    .expect("previous JWKS from library should be valid JSON");
-
-    let mut keys = active["keys"]
-        .as_array()
-        .expect("JWKS has keys array")
-        .clone();
-    keys.extend(
-        previous["keys"]
-            .as_array()
-            .expect("JWKS has keys array")
-            .iter()
-            .cloned(),
-    );
-
-    serde_json::json!({ "keys": keys }).to_string()
-}
-
-fn json_response(status: u16, body: &str) -> web_sys::Response {
-    let init = web_sys::ResponseInit::new();
-    init.set_status(status);
-    let headers = web_sys::Headers::new().unwrap();
-    let _ = headers.set("content-type", "application/json");
-    init.set_headers(&headers);
-    web_sys::Response::new_with_opt_str_and_init(Some(body), &init).unwrap()
 }
 
 // ── CORS ────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ use multistore_cf_workers::{
     collect_js_body, error_response, headermap_from_js, response_from_gateway, xml_response,
     JsBody, NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
 };
+use multistore_oidc_provider::discovery::openid_configuration_json;
+use multistore_oidc_provider::jwt::JwtSigner;
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use registry::SourceCoopRegistry;
 use worker::{event, Context, Env, Result};
@@ -50,6 +52,21 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // ── Short-circuit: OPTIONS preflight ────────────────────────────
     if method == http::Method::OPTIONS {
         return Ok(add_cors(error_response(204, "")));
+    }
+
+    // ── Short-circuit: OIDC discovery endpoints ─────────────────
+    if let Some(ref oidc) = config.oidc {
+        if path == "/.well-known/openid-configuration" && method == http::Method::GET {
+            let json = openid_configuration_json(
+                &oidc.issuer,
+                &format!("{}/.well-known/jwks.json", oidc.issuer),
+            );
+            return Ok(add_cors(json_response(200, &json)));
+        }
+        if path == "/.well-known/jwks.json" && method == http::Method::GET {
+            let json = build_jwks_json(oidc);
+            return Ok(add_cors(json_response(200, &json)));
+        }
     }
 
     // ── Short-circuit: write methods ───────────────────────────────
@@ -147,16 +164,62 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 struct AppConfig {
     api_base_url: String,
     api_secret: Option<String>,
+    oidc: Option<OidcConfig>,
+}
+
+struct OidcConfig {
+    signer: JwtSigner,
+    issuer: String,
+    /// Previous key for rotation — served in JWKS but not used for signing.
+    previous_signer: Option<JwtSigner>,
 }
 
 fn load_config(env: &Env) -> AppConfig {
+    let api_base_url = env
+        .var("SOURCE_API_URL")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| "https://source.coop".to_string());
+    let api_secret = env.secret("SOURCE_API_SECRET").map(|v| v.to_string()).ok();
+    let oidc = load_oidc_config(env);
+
     AppConfig {
-        api_base_url: env
-            .var("SOURCE_API_URL")
-            .map(|v| v.to_string())
-            .unwrap_or_else(|_| "https://source.coop".to_string()),
-        api_secret: env.secret("SOURCE_API_SECRET").map(|v| v.to_string()).ok(),
+        api_base_url,
+        api_secret,
+        oidc,
     }
+}
+
+fn load_oidc_config(env: &Env) -> Option<OidcConfig> {
+    let pem = env.secret("OIDC_PROVIDER_KEY").ok()?.to_string();
+    let kid = env.var("OIDC_PROVIDER_KID").ok()?.to_string();
+    let issuer = env.var("OIDC_PROVIDER_ISSUER").ok()?.to_string();
+
+    let signer = match JwtSigner::from_pem(&pem, kid, 60) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to load OIDC provider key: {}", e);
+            return None;
+        }
+    };
+
+    // Optional previous key for rotation
+    let previous_signer = (|| {
+        let prev_pem = env.secret("OIDC_PROVIDER_KEY_PREVIOUS").ok()?.to_string();
+        let prev_kid = env.var("OIDC_PROVIDER_KID_PREVIOUS").ok()?.to_string();
+        match JwtSigner::from_pem(&prev_pem, prev_kid, 60) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!("failed to load previous OIDC key: {}", e);
+                None
+            }
+        }
+    })();
+
+    Some(OidcConfig {
+        signer,
+        issuer,
+        previous_signer,
+    })
 }
 
 fn init_tracing(env: &Env) -> tracing::Level {
@@ -325,6 +388,44 @@ fn maybe_broadcast_location(ctx: &Context, env: &Env, event: LocationEvent) {
             .fetch("https://public-log-stream/location", Some(init))
             .await;
     });
+}
+
+// ── OIDC helpers ────────────────────────────────────────────────────
+
+/// Build JWKS JSON containing the active key and optionally the previous key.
+fn build_jwks_json(oidc: &OidcConfig) -> String {
+    use multistore_oidc_provider::jwks::jwks_json as single_jwks_json;
+
+    if oidc.previous_signer.is_none() {
+        return single_jwks_json(oidc.signer.public_key(), oidc.signer.kid());
+    }
+
+    // Parse both single-key JWKS and merge their "keys" arrays
+    let active: serde_json::Value = serde_json::from_str(&single_jwks_json(
+        oidc.signer.public_key(),
+        oidc.signer.kid(),
+    ))
+    .unwrap();
+    let previous_signer = oidc.previous_signer.as_ref().unwrap();
+    let previous: serde_json::Value = serde_json::from_str(&single_jwks_json(
+        previous_signer.public_key(),
+        previous_signer.kid(),
+    ))
+    .unwrap();
+
+    let mut keys = active["keys"].as_array().unwrap().clone();
+    keys.extend(previous["keys"].as_array().unwrap().iter().cloned());
+
+    serde_json::json!({ "keys": keys }).to_string()
+}
+
+fn json_response(status: u16, body: &str) -> web_sys::Response {
+    let init = web_sys::ResponseInit::new();
+    init.set_status(status);
+    let headers = web_sys::Headers::new().unwrap();
+    let _ = headers.set("content-type", "application/json");
+    init.set_headers(&headers);
+    web_sys::Response::new_with_opt_str_and_init(Some(body), &init).unwrap()
 }
 
 // ── CORS ────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 mod analytics;
+mod auth;
 mod cache;
 mod config;
 mod handlers;
 mod pagination;
 mod registry;
 
+use crate::auth::ApiAuth;
 use analytics::{extract_path_segments, log_request, RequestEvent};
 use handlers::{AccountListHandler, IndexHandler};
 use multistore::api::response::ErrorResponse;
@@ -15,7 +17,6 @@ use multistore_cf_workers::{
     collect_js_body, error_response, headermap_from_js, response_from_gateway, xml_response,
     JsBody, NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
 };
-use multistore_oidc_provider::jwt::JwtSigner;
 use multistore_oidc_provider::route_handler::OidcRouterExt;
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use registry::SourceCoopRegistry;
@@ -83,11 +84,11 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     };
 
     // ── Build API auth ─────────────────────────────────────────────
-    let api_auth = ApiAuth {
-        signer: Box::new(config.oidc.signer.clone()),
-        issuer: config.oidc.issuer.clone(),
-        audience: config.api_base_url.clone(),
-    };
+    let api_auth = ApiAuth::new(
+        config.oidc.signer.clone(),
+        config.oidc.issuer.clone(),
+        config.api_base_url.clone(),
+    );
 
     // ── Build gateway with route handlers ──────────────────────────
     let registry = SourceCoopRegistry::new(
@@ -165,29 +166,6 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-/// How the proxy authenticates to the Source Cooperative API.
-#[derive(Clone)]
-pub(crate) struct ApiAuth {
-    signer: Box<JwtSigner>,
-    issuer: String,
-    audience: String,
-}
-
-impl ApiAuth {
-    fn authorization_header(&self) -> Option<String> {
-        match self
-            .signer
-            .sign("data-proxy", &self.issuer, &self.audience, &[])
-        {
-            Ok(token) => Some(format!("Bearer {}", token)),
-            Err(e) => {
-                tracing::error!("failed to sign API auth JWT: {}", e);
-                None
-            }
-        }
-    }
-}
 
 fn init_tracing(env: &Env) -> tracing::Level {
     let max_level = env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,15 +191,19 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let (account, product, key) = extract_path_segments(&parts.path);
 
     // ── Analytics ───────────────────────────────────────────────
-    log_analytics(
-        &env,
-        &parts.headers,
-        &response,
-        &parts.method,
-        account,
-        product,
-        key,
-    );
+    // Special endpoints (`/.well-known/*`, `/.sts`) aren't product requests;
+    // logging them would pollute the dataset with account = ".well-known".
+    if !parts.path.starts_with("/.") {
+        log_analytics(
+            &env,
+            &parts.headers,
+            &response,
+            &parts.method,
+            account,
+            product,
+            key,
+        );
+    }
 
     // ── Broadcast location to WebSocket viewers ──────────────────
     if let (&http::Method::GET, Some(acct), Some(prod)) = (&parts.method, account, product) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,14 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let config = load_config(&env);
 
     // ── Parse request ──────────────────────────────────────────────
-    let (parts, js_body) = RequestParts::from_web_sys(&req)
+    let (mut parts, js_body) = RequestParts::from_web_sys(&req)
         .map_err(|e| worker::Error::RustError(format!("invalid request: {e}")))?;
+
+    // The router matches `/.sts` exactly; a trailing-slash variant would
+    // otherwise fall through to bucket mapping and 404 confusingly.
+    if parts.path == "/.sts/" {
+        parts.path.pop();
+    }
 
     let request_id = extract_request_id(&parts.headers);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod sts;
 use crate::auth::ApiAuth;
 use analytics::{extract_path_segments, log_request, RequestEvent};
 use handlers::{AccountListHandler, IndexHandler};
+use multistore::api::response::ErrorResponse;
 use multistore::proxy::ProxyGateway;
 use multistore::route_handler::RequestInfo;
 use multistore::router::Router;
@@ -67,6 +68,24 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         return Ok(add_cors(empty_response(204)));
     }
 
+    // Special endpoints (OIDC discovery, STS token exchange) manage their own
+    // methods and bypass the S3 object/bucket path mapping below.
+    let is_special_path = parts.path.starts_with("/.well-known/") || parts.path == "/.sts";
+
+    // ── Short-circuit: write methods ────────────────────────────────
+    // The proxy is read-only for object/bucket paths, so writes get an
+    // S3-style 405 rather than falling through to bucket resolution (which
+    // would misleadingly 404). Special endpoints are exempt.
+    if !is_special_path && is_write_method(&parts.method) {
+        let resp = ErrorResponse {
+            code: "MethodNotAllowed".to_string(),
+            message: "Method Not Allowed".to_string(),
+            resource: String::new(),
+            request_id: request_id.clone(),
+        };
+        return Ok(add_cors(xml_response(405, &resp.to_xml())));
+    }
+
     // ── Path rewriting ─────────────────────────────────────────────
     // Source Cooperative path mapping: `/{account}/{product}/{key}`
     // → internal bucket `account:product`, display name shows just `account`.
@@ -75,7 +94,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         bucket_separator: BUCKET_SEPARATOR.to_string(),
         display_bucket_segments: 1,
     };
-    let rewrite = if parts.path.starts_with("/.well-known/") || parts.path == "/.sts" {
+    let rewrite = if is_special_path {
         multistore_path_mapping::RewriteResult {
             path: parts.path.clone(),
             query: parts.query.clone(),
@@ -205,6 +224,13 @@ fn init_tracing(env: &Env) -> tracing::Level {
         .unwrap_or(tracing::Level::WARN);
     tracing::subscriber::set_global_default(WorkerSubscriber::new().with_max_level(max_level)).ok();
     max_level
+}
+
+fn is_write_method(method: &http::Method) -> bool {
+    matches!(
+        *method,
+        http::Method::PUT | http::Method::POST | http::Method::DELETE | http::Method::PATCH
+    )
 }
 
 fn extract_request_id(headers: &http::HeaderMap) -> String {
@@ -363,6 +389,18 @@ fn empty_response(status: u16) -> web_sys::Response {
     init.set_status(status);
     web_sys::Response::new_with_opt_str_and_init(None, &init)
         .unwrap_or_else(|_| web_sys::Response::new().unwrap())
+}
+
+/// Build an `application/xml` response from a body string (e.g. an S3-style error).
+fn xml_response(status: u16, body: &str) -> web_sys::Response {
+    let init = web_sys::ResponseInit::new();
+    init.set_status(status);
+    let resp = web_sys::Response::new_with_opt_str_and_init(Some(body), &init)
+        .unwrap_or_else(|_| empty_response(status));
+    if let Err(e) = resp.headers().set("content-type", "application/xml") {
+        tracing::warn!("failed to set content-type on xml response: {:?}", e);
+    }
+    resp
 }
 
 // ── CORS ────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,11 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         bucket_separator: BUCKET_SEPARATOR.to_string(),
         display_bucket_segments: 1,
     };
-    let (rewritten_path, rewritten_query) = mapping.rewrite_request(&path, query.as_deref());
+    let (rewritten_path, rewritten_query) = if path.starts_with("/.well-known/") {
+        (path.clone(), query.clone())
+    } else {
+        mapping.rewrite_request(&path, query.as_deref())
+    };
 
     // ── Build API auth ─────────────────────────────────────────────
     let api_auth = ApiAuth {
@@ -100,7 +104,6 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     )
     .with_router(
         Router::new()
-            // OIDC discovery routes (served from this proxy)
             .with_oidc_discovery(
                 config.oidc.issuer.clone(),
                 std::iter::once(config.oidc.signer.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,17 +126,20 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let span = tracing::info_span!("request", %request_id, %method, %path);
     let _guard = span.enter();
 
-    let req_info = RequestInfo::new(
-        &method,
-        &rewrite.path,
-        rewrite.query.as_deref(),
-        &headers,
-        None,
-    )
-    .with_signing_path(&rewrite.signing_path)
-    .with_signing_query(rewrite.signing_query.as_deref());
     let result = gateway
-        .handle_request(&req_info, js_body, collect_js_body)
+        .handle_request(
+            &RequestInfo::new(
+                &method,
+                &rewrite.path,
+                rewrite.query.as_deref(),
+                &headers,
+                None,
+            )
+            .with_signing_path(&rewrite.signing_path)
+            .with_signing_query(rewrite.signing_query.as_deref()),
+            js_body,
+            collect_js_body,
+        )
         .await;
     let response = response_from_gateway(result);
     tracing::info!(status = response.status(), "response");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,24 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         ));
     }
 
+    // ── Short-circuit: STS disabled (fail closed) ───────────────────
+    // `/.sts` requires an audience restriction (AUTH_AUDIENCE) to be safe —
+    // without it, an ID token minted for any OAuth client of AUTH_ISSUER could
+    // be exchanged for a user's credentials. When unset, refuse the endpoint
+    // with a 501 rather than serving it unrestricted.
+    if parts.path == "/.sts" && config.auth_audience.is_none() {
+        let resp = ErrorResponse {
+            code: "NotImplemented".to_string(),
+            message: "STS token exchange is not configured".to_string(),
+            resource: String::new(),
+            request_id: request_id.clone(),
+        };
+        return Ok(add_cors(
+            GatewayResponse::Response(ProxyResult::xml(501, resp.to_xml())).into_web_sys(),
+            cors_allow_post,
+        ));
+    }
+
     // ── Path rewriting ─────────────────────────────────────────────
     // Source Cooperative path mapping: `/{account}/{product}/{key}`
     // → internal bucket `account:product`, display name shows just `account`.
@@ -132,29 +150,32 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         request_id.clone(),
     );
 
-    // ── Build STS components ─────────────────────────────────────
-    let sts_registry =
-        StsCredentialRegistry::new(config.auth_issuer.clone(), config.auth_audience.clone());
-    let jwks_cache = jwks_cache();
+    // ── Build router ─────────────────────────────────────────────
+    let mut router = Router::new().with_oidc_discovery(
+        config.oidc.issuer.clone(),
+        std::iter::once(config.oidc.signer.clone())
+            .chain(config.oidc.previous_signer.clone())
+            .collect(),
+    );
 
-    let router = Router::new()
-        .with_oidc_discovery(
-            config.oidc.issuer.clone(),
-            std::iter::once(config.oidc.signer.clone())
-                .chain(config.oidc.previous_signer.clone())
-                .collect(),
-        )
-        .with_sts(
+    // Mount STS token exchange only when an audience restriction is configured.
+    // The unset case is refused by the fail-closed 501 short-circuit above, so
+    // an unrestricted exchanger is never registered.
+    if let Some(audience) = &config.auth_audience {
+        let sts_registry =
+            StsCredentialRegistry::new(config.auth_issuer.clone(), Some(audience.clone()));
+        router = router.with_sts(
             "/.sts",
-            sts_registry.clone(),
-            jwks_cache,
+            sts_registry,
+            jwks_cache(),
             Some(config.session_token_key.clone()),
-        )
-        .route("/", IndexHandler)
-        .route(
-            "/{bucket}",
-            AccountListHandler::new(registry.clone(), &mapping),
         );
+    }
+
+    let router = router.route("/", IndexHandler).route(
+        "/{bucket}",
+        AccountListHandler::new(registry.clone(), &mapping),
+    );
 
     let gateway = ProxyGateway::new(
         WorkerBackend,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,16 +452,25 @@ fn build_jwks_json(oidc: &OidcConfig) -> String {
         oidc.signer.public_key(),
         oidc.signer.kid(),
     ))
-    .unwrap();
-    let previous_signer = oidc.previous_signer.as_ref().unwrap();
+    .expect("active JWKS from library should be valid JSON");
+    let previous_signer = oidc.previous_signer.as_ref().expect("checked above");
     let previous: serde_json::Value = serde_json::from_str(&single_jwks_json(
         previous_signer.public_key(),
         previous_signer.kid(),
     ))
-    .unwrap();
+    .expect("previous JWKS from library should be valid JSON");
 
-    let mut keys = active["keys"].as_array().unwrap().clone();
-    keys.extend(previous["keys"].as_array().unwrap().iter().cloned());
+    let mut keys = active["keys"]
+        .as_array()
+        .expect("JWKS has keys array")
+        .clone();
+    keys.extend(
+        previous["keys"]
+            .as_array()
+            .expect("JWKS has keys array")
+            .iter()
+            .cloned(),
+    );
 
     serde_json::json!({ "keys": keys }).to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,21 +5,24 @@ mod config;
 mod handlers;
 mod pagination;
 mod registry;
+mod sts;
 
 use crate::auth::ApiAuth;
 use analytics::{extract_path_segments, log_request, RequestEvent};
 use handlers::{AccountListHandler, IndexHandler};
-use multistore::api::response::ErrorResponse;
 use multistore::proxy::ProxyGateway;
 use multistore::route_handler::RequestInfo;
 use multistore::router::Router;
 use multistore_cf_workers::{
-    collect_js_body, error_response, headermap_from_js, response_from_gateway, xml_response,
-    JsBody, NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
+    collect_js_body, error_response, headermap_from_js, response_from_gateway, JsBody,
+    NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
 };
 use multistore_oidc_provider::route_handler::OidcRouterExt;
 use multistore_path_mapping::{MappedRegistry, PathMapping};
+use multistore_sts::jwks::JwksCache;
+use multistore_sts::route_handler::StsRouterExt;
 use registry::SourceCoopRegistry;
+use sts::StsCredentialRegistry;
 use worker::{event, Context, Env, Result};
 
 use crate::config::load_config;
@@ -44,29 +47,13 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         .decode_utf8_lossy()
         .to_string();
     let query = uri.query().map(|q| q.to_string());
-    let mut headers = headermap_from_js(&req.headers());
-
-    // Strip AWS auth headers — this proxy is anonymous-only.
-    headers.remove(http::header::AUTHORIZATION);
-    headers.remove("x-amz-security-token");
-    headers.remove("x-amz-content-sha256");
+    let headers = headermap_from_js(&req.headers());
 
     let request_id = extract_request_id(&headers);
 
     // ── Short-circuit: OPTIONS preflight ────────────────────────────
     if method == http::Method::OPTIONS {
         return Ok(add_cors(error_response(204, "")));
-    }
-
-    // ── Short-circuit: write methods ───────────────────────────────
-    if is_write_method(&method) {
-        let resp = ErrorResponse {
-            code: "MethodNotAllowed".to_string(),
-            message: "Method Not Allowed".to_string(),
-            resource: String::new(),
-            request_id: request_id.to_string(),
-        };
-        return Ok(add_cors(xml_response(405, &resp.to_xml())));
     }
 
     // ── Path rewriting ─────────────────────────────────────────────
@@ -77,7 +64,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         bucket_separator: BUCKET_SEPARATOR.to_string(),
         display_bucket_segments: 1,
     };
-    let (rewritten_path, rewritten_query) = if path.starts_with("/.well-known/") {
+    let (rewritten_path, rewritten_query) = if path.starts_with("/.well-known/") || path == "/.sts"
+    {
         (path.clone(), query.clone())
     } else {
         mapping.rewrite_request(&path, query.as_deref())
@@ -97,24 +85,41 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         request_id.clone(),
     );
 
+    // ── Build STS components ─────────────────────────────────────
+    let sts_registry = StsCredentialRegistry::new(config.auth_issuer.clone());
+    let jwks_cache = JwksCache::new(reqwest::Client::new(), std::time::Duration::from_secs(900));
+
+    let router = Router::new()
+        .with_oidc_discovery(
+            config.oidc.issuer.clone(),
+            std::iter::once(config.oidc.signer.clone())
+                .chain(config.oidc.previous_signer.clone())
+                .collect(),
+        )
+        .with_sts(
+            "/.sts",
+            sts_registry.clone(),
+            jwks_cache,
+            Some(config.session_token_key.clone()),
+        )
+        .route("/", IndexHandler)
+        .route(
+            "/{bucket}",
+            AccountListHandler::new(registry.clone(), &mapping),
+        );
+
     let gateway = ProxyGateway::new(
         WorkerBackend,
-        MappedRegistry::new(registry.clone(), mapping.clone()),
+        MappedRegistry::new(registry, mapping.clone()),
         NoopCredentialRegistry,
         None,
     )
-    .with_router(
-        Router::new()
-            .with_oidc_discovery(
-                config.oidc.issuer.clone(),
-                std::iter::once(config.oidc.signer.clone())
-                    .chain(config.oidc.previous_signer.clone())
-                    .collect(),
-            )
-            .route("/", IndexHandler)
-            .route("/{bucket}", AccountListHandler::new(registry, &mapping)),
-    )
+    .with_router(router)
     .with_debug_errors(max_level >= tracing::Level::DEBUG);
+
+    // Register the token key as credential resolver so sealed STS tokens
+    // can be verified on subsequent authenticated requests.
+    let gateway = gateway.with_credential_resolver(config.session_token_key.clone());
 
     // ── Dispatch through gateway ──────────────────────────────────
     let span = tracing::info_span!("request", %request_id, %method, %path);
@@ -191,13 +196,6 @@ fn header_str<'a>(headers: &'a http::HeaderMap, name: &str) -> &'a str {
         .get(name)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
-}
-
-fn is_write_method(method: &http::Method) -> bool {
-    matches!(
-        *method,
-        http::Method::PUT | http::Method::POST | http::Method::DELETE | http::Method::PATCH
-    )
 }
 
 // ── Analytics ──────────────────────────────────────────────────────
@@ -308,6 +306,7 @@ fn maybe_broadcast_location(ctx: &Context, env: &Env, event: LocationEvent) {
             &event.product,
             &event.api_auth,
             "",
+            None,
         )
         .await
         .map(|p| p.is_public())
@@ -341,7 +340,10 @@ fn add_cors(resp: web_sys::Response) -> web_sys::Response {
     let h = resp.headers();
     for (name, value) in [
         ("access-control-allow-origin", "*"),
-        ("access-control-allow-methods", "GET, HEAD, OPTIONS"),
+        (
+            "access-control-allow-methods",
+            "GET, HEAD, PUT, POST, DELETE, OPTIONS",
+        ),
         ("access-control-allow-headers", "*"),
         ("access-control-expose-headers", "*"),
     ] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         rewritten_query.as_deref(),
         &headers,
         None,
-    );
+    )
+    .with_signing_path(&path);
     let result = gateway
         .handle_request(&req_info, js_body, collect_js_body)
         .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,13 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         bucket_separator: BUCKET_SEPARATOR.to_string(),
         display_bucket_segments: 1,
     };
-    let (rewritten_path, rewritten_query) = if path.starts_with("/.well-known/") || path == "/.sts"
-    {
-        (path.clone(), query.clone())
+    let rewrite = if path.starts_with("/.well-known/") || path == "/.sts" {
+        multistore_path_mapping::RewriteResult {
+            path: path.clone(),
+            query: query.clone(),
+            signing_path: path.clone(),
+            signing_query: query.clone(),
+        }
     } else {
         mapping.rewrite_request(&path, query.as_deref())
     };
@@ -127,12 +131,13 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
     let req_info = RequestInfo::new(
         &method,
-        &rewritten_path,
-        rewritten_query.as_deref(),
+        &rewrite.path,
+        rewrite.query.as_deref(),
         &headers,
         None,
     )
-    .with_signing_path(&path);
+    .with_signing_path(&rewrite.signing_path)
+    .with_signing_query(rewrite.signing_query.as_deref());
     let result = gateway
         .handle_request(&req_info, js_body, collect_js_body)
         .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ use crate::auth::ApiAuth;
 use analytics::{extract_path_segments, log_request, RequestEvent};
 use handlers::{AccountListHandler, IndexHandler};
 use multistore::api::response::ErrorResponse;
-use multistore::proxy::ProxyGateway;
-use multistore::route_handler::RequestInfo;
+use multistore::proxy::{GatewayResponse, ProxyGateway};
+use multistore::route_handler::{ProxyResult, RequestInfo};
 use multistore::router::Router;
 use multistore_cf_workers::{
     collect_js_body, GatewayResponseExt, NoopCredentialRegistry, RequestParts, WorkerBackend,
@@ -83,7 +83,9 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
             resource: String::new(),
             request_id: request_id.clone(),
         };
-        return Ok(add_cors(xml_response(405, &resp.to_xml())));
+        return Ok(add_cors(
+            GatewayResponse::Response(ProxyResult::xml(405, resp.to_xml())).into_web_sys(),
+        ));
     }
 
     // ── Path rewriting ─────────────────────────────────────────────
@@ -389,18 +391,6 @@ fn empty_response(status: u16) -> web_sys::Response {
     init.set_status(status);
     web_sys::Response::new_with_opt_str_and_init(None, &init)
         .unwrap_or_else(|_| web_sys::Response::new().unwrap())
-}
-
-/// Build an `application/xml` response from a body string (e.g. an S3-style error).
-fn xml_response(status: u16, body: &str) -> web_sys::Response {
-    let init = web_sys::ResponseInit::new();
-    init.set_status(status);
-    let resp = web_sys::Response::new_with_opt_str_and_init(Some(body), &init)
-        .unwrap_or_else(|_| empty_response(status));
-    if let Err(e) = resp.headers().set("content-type", "application/xml") {
-        tracing::warn!("failed to set content-type on xml response: {:?}", e);
-    }
-    resp
 }
 
 // ── CORS ────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
     // ── Broadcast location to WebSocket viewers ──────────────────
     if let (&http::Method::GET, Some(acct), Some(prod)) = (&method, account, product) {
-        if response.status() < 400 {
+        if response.status() < 400 && !path.starts_with("/.") {
             maybe_broadcast_location(
                 &ctx,
                 &env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,21 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     };
     let (rewritten_path, rewritten_query) = mapping.rewrite_request(&path, query.as_deref());
 
+    // ── Build API auth ─────────────────────────────────────────────
+    let api_auth = match (&config.oidc, &config.api_secret) {
+        (Some(oidc), _) => ApiAuth::Oidc {
+            signer: Box::new(oidc.signer.clone()),
+            issuer: oidc.issuer.clone(),
+            audience: config.api_base_url.clone(),
+        },
+        (None, Some(secret)) => ApiAuth::Secret(secret.clone()),
+        (None, None) => ApiAuth::None,
+    };
+
     // ── Build gateway with route handlers ──────────────────────────
     let registry = SourceCoopRegistry::new(
         config.api_base_url.clone(),
-        config.api_secret.clone(),
+        api_auth.clone(),
         request_id.clone(),
     );
 
@@ -146,7 +157,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
                     product: prod.to_string(),
                     key: key.unwrap_or("").to_string(),
                     api_base_url: config.api_base_url.clone(),
-                    api_secret: config.api_secret.clone(),
+                    api_auth: api_auth.clone(),
                 },
             );
         }
@@ -172,6 +183,42 @@ struct OidcConfig {
     issuer: String,
     /// Previous key for rotation — served in JWKS but not used for signing.
     previous_signer: Option<JwtSigner>,
+}
+
+/// How the proxy authenticates to the Source Cooperative API.
+#[derive(Clone)]
+pub(crate) enum ApiAuth {
+    /// OIDC JWT bearer token.
+    Oidc {
+        signer: Box<JwtSigner>,
+        issuer: String,
+        audience: String,
+    },
+    /// Static shared secret (legacy).
+    Secret(String),
+    /// No authentication.
+    None,
+}
+
+impl ApiAuth {
+    /// Generate an Authorization header value.
+    fn authorization_header(&self) -> Option<String> {
+        match self {
+            ApiAuth::Oidc {
+                signer,
+                issuer,
+                audience,
+            } => match signer.sign("data-proxy", issuer, audience, &[]) {
+                Ok(token) => Some(format!("Bearer {}", token)),
+                Err(e) => {
+                    tracing::error!("failed to sign API auth JWT: {}", e);
+                    None
+                }
+            },
+            ApiAuth::Secret(secret) => Some(secret.clone()),
+            ApiAuth::None => None,
+        }
+    }
 }
 
 fn load_config(env: &Env) -> AppConfig {
@@ -339,7 +386,7 @@ struct LocationEvent {
     product: String,
     key: String,
     api_base_url: String,
-    api_secret: Option<String>,
+    api_auth: ApiAuth,
 }
 
 /// Broadcast the request's geolocation to WebSocket viewers via the public-log-stream service.
@@ -361,7 +408,7 @@ fn maybe_broadcast_location(ctx: &Context, env: &Env, event: LocationEvent) {
             &event.api_base_url,
             &event.account,
             &event.product,
-            event.api_secret.as_deref(),
+            &event.api_auth,
             "",
         )
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     );
 
     // ── Build STS components ─────────────────────────────────────
-    let sts_registry = StsCredentialRegistry::new(config.auth_issuer.clone());
+    let sts_registry =
+        StsCredentialRegistry::new(config.auth_issuer.clone(), config.auth_audience.clone());
     let jwks_cache = jwks_cache();
 
     let router = Router::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,15 @@ use multistore::proxy::ProxyGateway;
 use multistore::route_handler::RequestInfo;
 use multistore::router::Router;
 use multistore_cf_workers::{
-    collect_js_body, error_response, headermap_from_js, response_from_gateway, JsBody,
-    NoopCredentialRegistry, WorkerBackend, WorkerSubscriber,
+    collect_js_body, GatewayResponseExt, NoopCredentialRegistry, RequestParts, WorkerBackend,
+    WorkerSubscriber,
 };
 use multistore_oidc_provider::route_handler::OidcRouterExt;
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use multistore_sts::jwks::JwksCache;
 use multistore_sts::route_handler::StsRouterExt;
 use registry::SourceCoopRegistry;
+use std::sync::OnceLock;
 use sts::StsCredentialRegistry;
 use worker::{event, Context, Env, Result};
 
@@ -30,6 +31,25 @@ use crate::config::load_config;
 /// Separator used to join account + product into a single internal bucket name.
 pub(crate) const BUCKET_SEPARATOR: &str = ":";
 
+/// Shared `reqwest::Client` reused across requests within an isolate.
+/// `reqwest::Client` is `Arc`-backed so cloning out of the cell is cheap.
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+fn http_client() -> reqwest::Client {
+    HTTP_CLIENT.get_or_init(reqwest::Client::new).clone()
+}
+
+/// Shared `JwksCache`. Its `entries`/`failures` maps are `Arc<Mutex<_>>` so
+/// cloning the cache is cheap and shares state — the 15-minute TTL is
+/// finally effective across requests.
+static JWKS_CACHE: OnceLock<JwksCache> = OnceLock::new();
+
+fn jwks_cache() -> JwksCache {
+    JWKS_CACHE
+        .get_or_init(|| JwksCache::new(http_client(), std::time::Duration::from_secs(900)))
+        .clone()
+}
+
 #[event(fetch)]
 async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys::Response> {
     console_error_panic_hook::set_once();
@@ -37,23 +57,14 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let config = load_config(&env);
 
     // ── Parse request ──────────────────────────────────────────────
-    let js_body = JsBody(req.body());
-    let method: http::Method = req.method().parse().unwrap_or(http::Method::GET);
-    let uri: http::Uri = req
-        .url()
-        .parse()
-        .unwrap_or_else(|_| http::Uri::from_static("/"));
-    let path = percent_encoding::percent_decode_str(uri.path())
-        .decode_utf8_lossy()
-        .to_string();
-    let query = uri.query().map(|q| q.to_string());
-    let headers = headermap_from_js(&req.headers());
+    let (parts, js_body) = RequestParts::from_web_sys(&req)
+        .map_err(|e| worker::Error::RustError(format!("invalid request: {e}")))?;
 
-    let request_id = extract_request_id(&headers);
+    let request_id = extract_request_id(&parts.headers);
 
     // ── Short-circuit: OPTIONS preflight ────────────────────────────
-    if method == http::Method::OPTIONS {
-        return Ok(add_cors(error_response(204, "")));
+    if parts.method == http::Method::OPTIONS {
+        return Ok(add_cors(empty_response(204)));
     }
 
     // ── Path rewriting ─────────────────────────────────────────────
@@ -64,15 +75,15 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         bucket_separator: BUCKET_SEPARATOR.to_string(),
         display_bucket_segments: 1,
     };
-    let rewrite = if path.starts_with("/.well-known/") || path == "/.sts" {
+    let rewrite = if parts.path.starts_with("/.well-known/") || parts.path == "/.sts" {
         multistore_path_mapping::RewriteResult {
-            path: path.clone(),
-            query: query.clone(),
-            signing_path: path.clone(),
-            signing_query: query.clone(),
+            path: parts.path.clone(),
+            query: parts.query.clone(),
+            signing_path: parts.path.clone(),
+            signing_query: parts.query.clone(),
         }
     } else {
-        mapping.rewrite_request(&path, query.as_deref())
+        mapping.rewrite_request(&parts.path, parts.query.as_deref())
     };
 
     // ── Build API auth ─────────────────────────────────────────────
@@ -91,7 +102,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
     // ── Build STS components ─────────────────────────────────────
     let sts_registry = StsCredentialRegistry::new(config.auth_issuer.clone());
-    let jwks_cache = JwksCache::new(reqwest::Client::new(), std::time::Duration::from_secs(900));
+    let jwks_cache = jwks_cache();
 
     let router = Router::new()
         .with_oidc_discovery(
@@ -123,42 +134,49 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     .with_credential_resolver(config.session_token_key.clone());
 
     // ── Dispatch through gateway ──────────────────────────────────
-    let span = tracing::info_span!("request", %request_id, %method, %path);
+    let span =
+        tracing::info_span!("request", %request_id, method = %parts.method, path = %parts.path);
     let _guard = span.enter();
 
-    let result = gateway
-        .handle_request(
-            &RequestInfo::new(
-                &method,
-                &rewrite.path,
-                rewrite.query.as_deref(),
-                &headers,
-                None,
-            )
-            .with_signing_path(&rewrite.signing_path)
-            .with_signing_query(rewrite.signing_query.as_deref()),
-            js_body,
-            collect_js_body,
-        )
-        .await;
-    let response = response_from_gateway(result);
+    let request_info = RequestInfo::new(
+        &parts.method,
+        &rewrite.path,
+        rewrite.query.as_deref(),
+        &parts.headers,
+        None,
+    )
+    .with_signing_path(&rewrite.signing_path)
+    .with_signing_query(rewrite.signing_query.as_deref());
+
+    let response = gateway
+        .handle_request(&request_info, js_body, collect_js_body)
+        .await
+        .into_web_sys();
     tracing::info!(status = response.status(), "response");
 
     // ── Extract path segments (used by analytics + location broadcast) ──
-    let (account, product, key) = extract_path_segments(&path);
+    let (account, product, key) = extract_path_segments(&parts.path);
 
     // ── Analytics ───────────────────────────────────────────────
-    log_analytics(&env, &headers, &response, &method, account, product, key);
+    log_analytics(
+        &env,
+        &parts.headers,
+        &response,
+        &parts.method,
+        account,
+        product,
+        key,
+    );
 
     // ── Broadcast location to WebSocket viewers ──────────────────
-    if let (&http::Method::GET, Some(acct), Some(prod)) = (&method, account, product) {
-        if response.status() < 400 && !path.starts_with("/.") {
+    if let (&http::Method::GET, Some(acct), Some(prod)) = (&parts.method, account, product) {
+        if response.status() < 400 && !parts.path.starts_with("/.") {
             maybe_broadcast_location(
                 &ctx,
                 &env,
                 LocationEvent {
                     cf: CfProperties::from_request(&req),
-                    country: header_str(&headers, "cf-ipcountry").to_string(),
+                    country: header_str(&parts.headers, "cf-ipcountry").to_string(),
                     account: acct.to_string(),
                     product: prod.to_string(),
                     key: key.unwrap_or("").to_string(),
@@ -338,6 +356,13 @@ fn maybe_broadcast_location(ctx: &Context, env: &Env, event: LocationEvent) {
             .fetch("https://public-log-stream/location", Some(init))
             .await;
     });
+}
+
+fn empty_response(status: u16) -> web_sys::Response {
+    let init = web_sys::ResponseInit::new();
+    init.set_status(status);
+    web_sys::Response::new_with_opt_str_and_init(None, &init)
+        .unwrap_or_else(|_| web_sys::Response::new().unwrap())
 }
 
 // ── CORS ────────────────────────────────────────────────────────────

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,15 +12,15 @@ use std::collections::HashMap;
 #[derive(Clone)]
 pub struct SourceCoopRegistry {
     api_base_url: String,
-    api_secret: Option<String>,
+    api_auth: crate::ApiAuth,
     pub(crate) request_id: String,
 }
 
 impl SourceCoopRegistry {
-    pub fn new(api_base_url: String, api_secret: Option<String>, request_id: String) -> Self {
+    pub fn new(api_base_url: String, api_auth: crate::ApiAuth, request_id: String) -> Self {
         Self {
             api_base_url,
-            api_secret,
+            api_auth,
             request_id,
         }
     }
@@ -35,7 +35,7 @@ impl SourceCoopRegistry {
         let product_list = crate::cache::get_or_fetch_product_list(
             &self.api_base_url,
             account,
-            self.api_secret.as_deref(),
+            &self.api_auth,
             &self.request_id,
         )
         .await?;
@@ -61,7 +61,7 @@ impl BucketRegistry for SourceCoopRegistry {
             &self.api_base_url,
             account,
             product,
-            self.api_secret.as_deref(),
+            &self.api_auth,
             &self.request_id,
         )
         .await?;
@@ -87,25 +87,19 @@ async fn resolve_product_send(
     api_base_url: &str,
     account: &str,
     product: &str,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<BucketConfig, ProxyError> {
     let (tx, rx) = futures::channel::oneshot::channel();
     let api_base_url = api_base_url.to_string();
     let account = account.to_string();
     let product = product.to_string();
-    let api_secret = api_secret.map(|s| s.to_string());
+    let api_auth = api_auth.clone();
     let request_id = request_id.to_string();
 
     wasm_bindgen_futures::spawn_local(async move {
-        let result = resolve_product_inner(
-            &api_base_url,
-            &account,
-            &product,
-            api_secret.as_deref(),
-            &request_id,
-        )
-        .await;
+        let result =
+            resolve_product_inner(&api_base_url, &account, &product, &api_auth, &request_id).await;
         let _ = tx.send(result);
     });
 
@@ -118,7 +112,7 @@ async fn resolve_product_inner(
     api_base_url: &str,
     account: &str,
     product: &str,
-    api_secret: Option<&str>,
+    api_auth: &crate::ApiAuth,
     request_id: &str,
 ) -> Result<BucketConfig, ProxyError> {
     let span = tracing::info_span!(
@@ -131,7 +125,7 @@ async fn resolve_product_inner(
 
     // 1. Fetch product metadata
     let source_product =
-        crate::cache::get_or_fetch_product(api_base_url, account, product, api_secret, request_id)
+        crate::cache::get_or_fetch_product(api_base_url, account, product, api_auth, request_id)
             .await?;
 
     // 2. Find primary mirror
@@ -147,7 +141,7 @@ async fn resolve_product_inner(
 
     // 3. Fetch data connections to resolve the actual bucket
     let connections =
-        crate::cache::get_or_fetch_data_connections(api_base_url, api_secret, request_id).await?;
+        crate::cache::get_or_fetch_data_connections(api_base_url, api_auth, request_id).await?;
 
     let connection = connections
         .iter()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -255,11 +255,11 @@ async fn resolve_product_inner(
 
 #[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum DataMode {
+pub enum Visibility {
     #[default]
-    Open,
-    Subscription,
-    Private,
+    Public,
+    Unlisted,
+    Restricted,
     #[serde(other)]
     Unknown,
 }
@@ -270,13 +270,13 @@ pub struct SourceProduct {
     #[serde(default)]
     pub disabled: bool,
     #[serde(default)]
-    pub data_mode: DataMode,
+    pub visibility: Visibility,
     pub metadata: SourceProductMetadata,
 }
 
 impl SourceProduct {
     pub fn is_public(&self) -> bool {
-        !self.disabled && self.data_mode == DataMode::Open
+        !self.disabled && self.visibility == Visibility::Public
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -63,7 +63,7 @@ impl BucketRegistry for SourceCoopRegistry {
             ResolvedIdentity::Anonymous => None,
         };
 
-        let config = resolve_product_send(
+        let config = resolve_product(
             &self.api_base_url,
             account,
             product,
@@ -88,43 +88,8 @@ impl BucketRegistry for SourceCoopRegistry {
     }
 }
 
-/// Resolve a product to a BucketConfig, bridging the !Send worker::Fetch
-/// into a Send future via spawn_local + oneshot channel.
-async fn resolve_product_send(
-    api_base_url: &str,
-    account: &str,
-    product: &str,
-    api_auth: &crate::ApiAuth,
-    request_id: &str,
-    subject: Option<&str>,
-) -> Result<BucketConfig, ProxyError> {
-    let (tx, rx) = futures::channel::oneshot::channel();
-    let api_base_url = api_base_url.to_string();
-    let account = account.to_string();
-    let product = product.to_string();
-    let api_auth = api_auth.clone();
-    let request_id = request_id.to_string();
-    let subject = subject.map(|s| s.to_string());
-
-    wasm_bindgen_futures::spawn_local(async move {
-        let result = resolve_product_inner(
-            &api_base_url,
-            &account,
-            &product,
-            &api_auth,
-            &request_id,
-            subject.as_deref(),
-        )
-        .await;
-        let _ = tx.send(result);
-    });
-
-    rx.await
-        .unwrap_or_else(|_| Err(ProxyError::Internal("registry channel dropped".into())))
-}
-
-/// Inner product resolution logic (runs in spawn_local, !Send is OK).
-async fn resolve_product_inner(
+/// Resolve a product to a `BucketConfig` by querying the Source Cooperative API.
+async fn resolve_product(
     api_base_url: &str,
     account: &str,
     product: &str,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -37,6 +37,7 @@ impl SourceCoopRegistry {
             account,
             &self.api_auth,
             &self.request_id,
+            None,
         )
         .await?;
         Ok(product_list
@@ -51,11 +52,16 @@ impl BucketRegistry for SourceCoopRegistry {
     async fn get_bucket(
         &self,
         name: &str,
-        _identity: &ResolvedIdentity,
+        identity: &ResolvedIdentity,
         _operation: &S3Operation,
     ) -> Result<ResolvedBucket, ProxyError> {
         let (account, product) = Self::parse_bucket_name(name)
             .ok_or_else(|| ProxyError::BucketNotFound(name.to_string()))?;
+
+        let subject = match identity {
+            ResolvedIdentity::Authenticated(auth) => Some(auth.principal_name.as_str()),
+            ResolvedIdentity::Anonymous => None,
+        };
 
         let config = resolve_product_send(
             &self.api_base_url,
@@ -63,6 +69,7 @@ impl BucketRegistry for SourceCoopRegistry {
             product,
             &self.api_auth,
             &self.request_id,
+            subject,
         )
         .await?;
 
@@ -89,6 +96,7 @@ async fn resolve_product_send(
     product: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<BucketConfig, ProxyError> {
     let (tx, rx) = futures::channel::oneshot::channel();
     let api_base_url = api_base_url.to_string();
@@ -96,10 +104,18 @@ async fn resolve_product_send(
     let product = product.to_string();
     let api_auth = api_auth.clone();
     let request_id = request_id.to_string();
+    let subject = subject.map(|s| s.to_string());
 
     wasm_bindgen_futures::spawn_local(async move {
-        let result =
-            resolve_product_inner(&api_base_url, &account, &product, &api_auth, &request_id).await;
+        let result = resolve_product_inner(
+            &api_base_url,
+            &account,
+            &product,
+            &api_auth,
+            &request_id,
+            subject.as_deref(),
+        )
+        .await;
         let _ = tx.send(result);
     });
 
@@ -114,6 +130,7 @@ async fn resolve_product_inner(
     product: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
+    subject: Option<&str>,
 ) -> Result<BucketConfig, ProxyError> {
     let span = tracing::info_span!(
         "resolve_product",
@@ -124,9 +141,15 @@ async fn resolve_product_inner(
     let _guard = span.enter();
 
     // 1. Fetch product metadata
-    let source_product =
-        crate::cache::get_or_fetch_product(api_base_url, account, product, api_auth, request_id)
-            .await?;
+    let source_product = crate::cache::get_or_fetch_product(
+        api_base_url,
+        account,
+        product,
+        api_auth,
+        request_id,
+        subject,
+    )
+    .await?;
 
     // 2. Find primary mirror
     let primary_key = &source_product.metadata.primary_mirror;
@@ -141,7 +164,8 @@ async fn resolve_product_inner(
 
     // 3. Fetch data connections to resolve the actual bucket
     let connections =
-        crate::cache::get_or_fetch_data_connections(api_base_url, api_auth, request_id).await?;
+        crate::cache::get_or_fetch_data_connections(api_base_url, api_auth, request_id, subject)
+            .await?;
 
     let connection = connections
         .iter()
@@ -193,7 +217,9 @@ async fn resolve_product_inner(
         _ => {}
     }
 
-    // Anonymous access — skip signing
+    // TODO: For authenticated users, provide real backend credentials so that
+    // write operations can be forwarded to the storage backend. Currently all
+    // requests use anonymous/unsigned access, so writes will fail at the backend.
     backend_options.insert("skip_signature".to_string(), "true".to_string());
 
     // 5. Build prefix: connection.base_prefix + mirror.prefix

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -1,0 +1,57 @@
+//! STS credential registry for token exchange.
+//!
+//! Provides a hardcoded `_default` role that trusts the Source Cooperative auth
+//! provider, enabling clients to exchange OIDC tokens for temporary S3-style credentials.
+
+use multistore::error::ProxyError;
+use multistore::registry::CredentialRegistry;
+use multistore::types::{RoleConfig, StoredCredential};
+
+/// Credential registry that serves a single hardcoded `_default` role.
+///
+/// The default role trusts the Source Cooperative auth provider with no
+/// scope restrictions, allowing any authenticated user to obtain temporary
+/// credentials.
+#[derive(Clone)]
+pub struct StsCredentialRegistry {
+    default_role: RoleConfig,
+}
+
+impl StsCredentialRegistry {
+    /// Create a new registry whose `_default` role trusts the given auth issuer.
+    pub fn new(oidc_issuer: String) -> Self {
+        Self {
+            default_role: RoleConfig {
+                role_id: "_default".to_string(),
+                name: "Default".to_string(),
+                trusted_oidc_issuers: vec![oidc_issuer],
+                required_audience: None,
+                subject_conditions: vec![],
+                allowed_scopes: vec![], // unlimited
+                max_session_duration_secs: 3600,
+            },
+        }
+    }
+}
+
+impl CredentialRegistry for StsCredentialRegistry {
+    async fn get_credential(
+        &self,
+        _access_key_id: &str,
+    ) -> Result<Option<StoredCredential>, ProxyError> {
+        // No long-lived credentials — all access is via STS token exchange.
+        Ok(None)
+    }
+
+    async fn get_role(&self, role_id: &str) -> Result<Option<RoleConfig>, ProxyError> {
+        // TODO: Eventually look up roles via the Source Cooperative API so that
+        // individual repositories can define custom roles with fine-grained
+        // scope and subject restrictions (e.g. per-repo CI/CD access).
+        // For now, only the hardcoded `_default` role is supported.
+        if role_id == "_default" {
+            Ok(Some(self.default_role.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -19,13 +19,18 @@ pub struct StsCredentialRegistry {
 
 impl StsCredentialRegistry {
     /// Create a new registry whose `_default` role trusts the given auth issuer.
-    pub fn new(oidc_issuer: String) -> Self {
+    ///
+    /// `required_audience` restricts token exchange to subject tokens minted
+    /// for a specific OAuth client (the `aud` claim). Without it, an ID token
+    /// a user granted to any third-party client registered with the issuer
+    /// could be exchanged for that user's proxy credentials.
+    pub fn new(oidc_issuer: String, required_audience: Option<String>) -> Self {
         Self {
             default_role: RoleConfig {
                 role_id: "_default".to_string(),
                 name: "Default".to_string(),
                 trusted_oidc_issuers: vec![oidc_issuer],
-                required_audience: None,
+                required_audience,
                 subject_conditions: vec![],
                 allowed_scopes: vec![], // unlimited
                 max_session_duration_secs: 3600,

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -12,114 +12,121 @@ fn mapping() -> PathMapping {
 
 #[test]
 fn root_path_passes_through() {
-    assert_eq!(
-        mapping().rewrite_request("/", None),
-        ("/".to_string(), None)
-    );
+    let result = mapping().rewrite_request("/", None);
+    assert_eq!(result.path, "/");
+    assert_eq!(result.query, None);
 }
 
 #[test]
 fn empty_path_passes_through() {
-    assert_eq!(mapping().rewrite_request("", None), ("".to_string(), None));
+    let result = mapping().rewrite_request("", None);
+    assert_eq!(result.path, "");
+    assert_eq!(result.query, None);
 }
 
 #[test]
 fn object_request_two_segments_plus_key() {
+    let result = mapping().rewrite_request("/cholmes/admin-boundaries/file.parquet", None);
+    assert_eq!(result.path, "/cholmes:admin-boundaries/file.parquet");
+    assert_eq!(result.query, None);
     assert_eq!(
-        mapping().rewrite_request("/cholmes/admin-boundaries/file.parquet", None),
-        ("/cholmes:admin-boundaries/file.parquet".to_string(), None)
+        result.signing_path,
+        "/cholmes/admin-boundaries/file.parquet"
     );
+    assert_eq!(result.signing_query, None);
 }
 
 #[test]
 fn object_request_nested_key() {
+    let result = mapping().rewrite_request("/cholmes/admin-boundaries/dir/sub/file.parquet", None);
     assert_eq!(
-        mapping().rewrite_request("/cholmes/admin-boundaries/dir/sub/file.parquet", None),
-        (
-            "/cholmes:admin-boundaries/dir/sub/file.parquet".to_string(),
-            None
-        )
+        result.path,
+        "/cholmes:admin-boundaries/dir/sub/file.parquet"
     );
+    assert_eq!(result.query, None);
+    assert_eq!(
+        result.signing_path,
+        "/cholmes/admin-boundaries/dir/sub/file.parquet"
+    );
+    assert_eq!(result.signing_query, None);
 }
 
 #[test]
 fn product_list_via_path_segment() {
-    assert_eq!(
-        mapping().rewrite_request("/cholmes/admin-boundaries", Some("list-type=2"),),
-        (
-            "/cholmes:admin-boundaries".to_string(),
-            Some("list-type=2".to_string())
-        )
-    );
+    let result = mapping().rewrite_request("/cholmes/admin-boundaries", Some("list-type=2"));
+    assert_eq!(result.path, "/cholmes:admin-boundaries");
+    assert_eq!(result.query, Some("list-type=2".to_string()));
+    assert_eq!(result.signing_path, "/cholmes/admin-boundaries");
+    assert_eq!(result.signing_query, Some("list-type=2".to_string()));
 }
 
 #[test]
 fn account_list_passes_through() {
-    assert_eq!(
-        mapping().rewrite_request("/cholmes", Some("list-type=2")),
-        ("/cholmes".to_string(), Some("list-type=2".to_string()))
-    );
+    let result = mapping().rewrite_request("/cholmes", Some("list-type=2"));
+    assert_eq!(result.path, "/cholmes");
+    assert_eq!(result.query, Some("list-type=2".to_string()));
 }
 
 #[test]
 fn account_list_trailing_slash_passes_through() {
-    assert_eq!(
-        mapping().rewrite_request("/cholmes/", Some("list-type=2")),
-        ("/cholmes/".to_string(), Some("list-type=2".to_string()))
-    );
+    let result = mapping().rewrite_request("/cholmes/", Some("list-type=2"));
+    assert_eq!(result.path, "/cholmes/");
+    assert_eq!(result.query, Some("list-type=2".to_string()));
 }
 
 #[test]
 fn prefix_routed_list() {
+    let result =
+        mapping().rewrite_request("/cholmes", Some("list-type=2&prefix=admin-boundaries/"));
+    assert_eq!(result.path, "/cholmes:admin-boundaries");
+    assert_eq!(result.query, Some("list-type=2&prefix=".to_string()));
+    assert_eq!(result.signing_path, "/cholmes");
     assert_eq!(
-        mapping().rewrite_request("/cholmes", Some("list-type=2&prefix=admin-boundaries/"),),
-        (
-            "/cholmes:admin-boundaries".to_string(),
-            Some("list-type=2&prefix=".to_string())
-        )
+        result.signing_query,
+        Some("list-type=2&prefix=admin-boundaries/".to_string())
     );
 }
 
 #[test]
 fn prefix_routed_list_with_subdir() {
+    let result = mapping().rewrite_request(
+        "/cholmes",
+        Some("list-type=2&prefix=admin-boundaries/subdir/"),
+    );
+    assert_eq!(result.path, "/cholmes:admin-boundaries");
+    assert_eq!(result.query, Some("list-type=2&prefix=subdir/".to_string()));
+    assert_eq!(result.signing_path, "/cholmes");
     assert_eq!(
-        mapping().rewrite_request(
-            "/cholmes",
-            Some("list-type=2&prefix=admin-boundaries/subdir/"),
-        ),
-        (
-            "/cholmes:admin-boundaries".to_string(),
-            Some("list-type=2&prefix=subdir/".to_string())
-        )
+        result.signing_query,
+        Some("list-type=2&prefix=admin-boundaries/subdir/".to_string())
     );
 }
 
 #[test]
 fn single_segment_no_list_passes_through() {
-    assert_eq!(
-        mapping().rewrite_request("/cholmes", None),
-        ("/cholmes".to_string(), None)
-    );
+    let result = mapping().rewrite_request("/cholmes", None);
+    assert_eq!(result.path, "/cholmes");
+    assert_eq!(result.query, None);
 }
 
 #[test]
 fn single_segment_with_non_list_query_passes_through() {
-    assert_eq!(
-        mapping().rewrite_request("/cholmes", Some("not-list-type=2")),
-        ("/cholmes".to_string(), Some("not-list-type=2".to_string()))
-    );
+    let result = mapping().rewrite_request("/cholmes", Some("not-list-type=2"));
+    assert_eq!(result.path, "/cholmes");
+    assert_eq!(result.query, Some("not-list-type=2".to_string()));
 }
 
 #[test]
 fn url_encoded_prefix() {
+    let result = mapping().rewrite_request(
+        "/cholmes",
+        Some("list-type=2&prefix=admin%20boundaries/subdir/"),
+    );
+    assert_eq!(result.path, "/cholmes:admin boundaries");
+    assert_eq!(result.query, Some("list-type=2&prefix=subdir/".to_string()));
+    assert_eq!(result.signing_path, "/cholmes");
     assert_eq!(
-        mapping().rewrite_request(
-            "/cholmes",
-            Some("list-type=2&prefix=admin%20boundaries/subdir/"),
-        ),
-        (
-            "/cholmes:admin boundaries".to_string(),
-            Some("list-type=2&prefix=subdir/".to_string())
-        )
+        result.signing_query,
+        Some("list-type=2&prefix=admin%20boundaries/subdir/".to_string())
     );
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,7 +24,7 @@ def test_index():
 
 def test_write_rejected():
     resp = requests.put(f"{PROXY_URL}/test/test/file.txt")
-    assert resp.status_code == 404
+    assert resp.status_code == 405
 
 
 def test_options_cors():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,7 +24,7 @@ def test_index():
 
 def test_write_rejected():
     resp = requests.put(f"{PROXY_URL}/test/test/file.txt")
-    assert resp.status_code == 405
+    assert resp.status_code == 404
 
 
 def test_options_cors():

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,10 +30,10 @@ SOURCE_API_URL = "https://source.coop"
 # Optional vars for key rotation:
 #   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key
 # Recommended vars:
+# Required vars (to enable /.sts token exchange):
 #   AUTH_AUDIENCE - OAuth client_id that /.sts subject tokens must be issued to
-#                   (the `aud` claim). Unset = tokens for ANY client of
-#                   AUTH_ISSUER are accepted at /.sts.
-
+#                   (the `aud` claim). Unset = /.sts is disabled (returns 501);
+#                   set to your OAuth client_id to enable it.
 # TODO: Set different sampling rates for prod vs staging
 [observability]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,7 +21,8 @@ OIDC_PROVIDER_KID = "data-proxy-1"
 # Required secrets (set via `wrangler secret put`):
 #   OIDC_PROVIDER_KEY          - PEM-encoded PKCS#8 RSA private key (active)
 #   OIDC_PROVIDER_KEY_PREVIOUS - PEM-encoded previous key (optional, for rotation)
-#   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key (optional, for rotation)
+# Optional vars for key rotation:
+#   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key
 
 # TODO: Set different sampling rates for prod vs staging
 [observability]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,14 +10,21 @@ routes = [
   {pattern = "d.data.source.coop/*", zone_name = "coolnewgeo.com"},
 ]
 
+[dev]
+# NOTE: Wrangler dev server overrides the host with the first route's host, so we need 
+# to set it to the same host as the first route to avoid signature mistmatch issues
+# during local development.
+host = "localhost:8787"
+
 [build]
 command = "cargo install -q worker-build@0.7.5 && worker-build --release"
 
 [vars]
 LOG_LEVEL = "WARN"
-SOURCE_API_URL = "https://source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
+SOURCE_API_URL = "https://source.coop"
+
 # Required secrets (set via `wrangler secret put`):
 #   OIDC_PROVIDER_KEY          - PEM-encoded PKCS#8 RSA private key (active)
 #   OIDC_PROVIDER_KEY_PREVIOUS - PEM-encoded previous key (optional, for rotation)
@@ -56,9 +63,9 @@ routes = [
 
 [env.staging.vars]
 LOG_LEVEL = "DEBUG"
-SOURCE_API_URL = "https://staging.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.staging.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
+SOURCE_API_URL = "https://staging.source.coop"
 
 [[env.staging.analytics_engine_datasets]]
 binding = "ANALYTICS"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,6 +16,12 @@ command = "cargo install -q worker-build@0.7.5 && worker-build --release"
 [vars]
 LOG_LEVEL = "WARN"
 SOURCE_API_URL = "https://source.coop"
+OIDC_PROVIDER_ISSUER = "https://data.source.coop"
+OIDC_PROVIDER_KID = "data-proxy-1"
+# Required secrets (set via `wrangler secret put`):
+#   OIDC_PROVIDER_KEY          - PEM-encoded PKCS#8 RSA private key (active)
+#   OIDC_PROVIDER_KEY_PREVIOUS - PEM-encoded previous key (optional, for rotation)
+#   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key (optional, for rotation)
 
 # TODO: Set different sampling rates for prod vs staging
 [observability]
@@ -50,6 +56,8 @@ routes = [
 [env.staging.vars]
 LOG_LEVEL = "DEBUG"
 SOURCE_API_URL = "https://staging.source.coop"
+OIDC_PROVIDER_ISSUER = "https://data.staging.source.coop"
+OIDC_PROVIDER_KID = "data-proxy-1"
 
 [[env.staging.analytics_engine_datasets]]
 binding = "ANALYTICS"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,11 +22,17 @@ OIDC_PROVIDER_ISSUER = "https://data.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
 SOURCE_API_URL = "https://source.coop"
 
-# Required secrets (set via `wrangler secret put`):
+# Required secrets (managed as GitHub environment secrets; CI re-uploads them
+# via `wrangler secret bulk` on every deploy — see .github/workflows/deploy.yml):
 #   OIDC_PROVIDER_KEY          - PEM-encoded PKCS#8 RSA private key (active)
+#   SESSION_TOKEN_KEY          - base64-encoded 32-byte AES key for sealing STS credentials
 #   OIDC_PROVIDER_KEY_PREVIOUS - PEM-encoded previous key (optional, for rotation)
 # Optional vars for key rotation:
 #   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key
+# Recommended vars:
+#   AUTH_AUDIENCE - OAuth client_id that /.sts subject tokens must be issued to
+#                   (the `aud` claim). Unset = tokens for ANY client of
+#                   AUTH_ISSUER are accepted at /.sts.
 
 # TODO: Set different sampling rates for prod vs staging
 [observability]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,7 @@ command = "cargo install -q worker-build@0.7.5 && worker-build --release"
 
 [vars]
 LOG_LEVEL = "WARN"
+AUTH_ISSUER = "https://auth.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
 SOURCE_API_URL = "https://source.coop"
@@ -61,6 +62,7 @@ routes = [
 
 [env.staging.vars]
 LOG_LEVEL = "DEBUG"
+AUTH_ISSUER = "https://auth.staging.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.staging.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
 SOURCE_API_URL = "https://staging.source.coop"


### PR DESCRIPTION
## What I'm changing

Turns the data proxy into an **OIDC provider** so it can authenticate to the Source Cooperative API *on behalf of each user*, and adds an **STS token-exchange endpoint** so clients can trade an OIDC token for temporary S3-style credentials.

### Highlights

- **OIDC provider** — the proxy now mints and signs RSA JWTs and publishes them at `GET /.well-known/openid-configuration` and `GET /.well-known/jwks.json`, so the Source API (and other relying parties) can verify them. Supports **zero-downtime key rotation** by serving both the active and previous key in the JWKS.
- **Per-user API auth** — replaces the single static `api_secret` with a flexible `ApiAuth` that signs a short-lived JWT scoped to the calling principal. Upstream API calls are now made *as that user* instead of with a shared secret.
- **STS token exchange** — new `/.sts` endpoint with a `_default` role that trusts the auth provider, letting an authenticated user obtain temporary credentials.

### Also included

- New `config` module parses keys/secrets once per isolate (RSA PEM parsed a single time).
- Object writes now return an S3 `405 MethodNotAllowed` instead of a misleading `404` (the proxy is read-only).
- Upstream auth failures (`401`/`403`) now surface as S3 `403 AccessDenied` rather than a `500`.
- Cache keys are identity-scoped and URL-safe (hex-encoded subject).
- Bumps `multistore` to `0.4.0`, refreshes dependencies / `cargo audit` allowlist, and updates CI + deploy workflows to forward the new secrets.

> [!WARNING] 
> this adds required env vars/secrets — `OIDC_PROVIDER_KEY`, `OIDC_PROVIDER_KID`, `OIDC_PROVIDER_ISSUER`, `SESSION_TOKEN_KEY`, `AUTH_ISSUER`. The worker will not boot without them. See the README → *OIDC Provider* for setup and the key-rotation procedure.

## How to test it

1. Access the accompanying frontend PR (https://github.com/source-cooperative/source.coop/pull/283) preview: https://source-cooperative-git-feat-oidc-auth-radiantearth.vercel.app/
1. Authenticate & access Restricted product (e.g. https://source-cooperative-git-feat-oidc-auth-radiantearth.vercel.app/alukach/alukach-experimentation). Verify ****

3. Set the env vars/secrets above (the README has a one-liner to generate an RSA key).
4. **Discovery:** `curl https://<host>/.well-known/openid-configuration` and `/.well-known/jwks.json` return the issuer and the active (+ previous, during rotation) keys.
5. **Token exchange:** exchange an OIDC token at `/.sts` and confirm temporary credentials are returned.
6. **Behavior:** a signed object download still streams; a `PUT`/`POST`/`DELETE` returns `405`; a request the API rejects returns `403 AccessDenied` (not `500`).

## PR Checklist

- [ ] This PR has **no** breaking changes. <!-- Note: requires new env vars/secrets to deploy — see Deploy note above. -->
- [ ] I have updated or added new tests to cover the changes in this PR.
- [x] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

## Related Issues

- https://github.com/source-cooperative/source.coop/issues/237
