### PR TITLE
feat: per-connection backend authentication via OIDC federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,8 +908,9 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ae47947aa57e1cfefcbe1eba035abd0033154c56e95812e9a34cf4c43aad06"
 dependencies = [
  "async-trait",
  "base64",
@@ -934,8 +935,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518e3a40526f673ed6b0e032c9cec7f45c917a7a50fdf7fca375f27b16e0f253"
 dependencies = [
  "async-trait",
  "bytes",
@@ -958,12 +960,13 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b3ee44b4a1f68ce7b97f288cf1f105f6e5d2f073c2bb06617b9380c29235d4"
 dependencies = [
- "async-trait",
  "base64",
  "chrono",
+ "futures",
  "multistore",
  "quick-xml 0.37.5",
  "rsa",
@@ -977,8 +980,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc11cdbe2bb11e105db4ceb63cdcf0ed89155df0f2da6248bcd532666d3db27"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -987,11 +991,11 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97639b653d38ac5a5bdc01fe400275df028a481188634bee21991a211e19b9e6"
 dependencies = [
  "aes-gcm",
- "async-trait",
  "base64",
  "chrono",
  "multistore",
@@ -1002,7 +1006,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,8 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7fb1fa70d7a75a57e322825fa61da83bfaef5a6e705ad871b8bad46db55b"
+source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,8 +935,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941b094b16c87594cdda4952e52c1a70bc19ca8a89985fc8d63a82b9b7feb6a9"
+source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -961,13 +959,13 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249fb5386150184f591170ddfb0916ae9fe1861c3523d8ae84b638cad22f5e76"
+source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
 dependencies = [
  "async-trait",
  "base64",
  "chrono",
  "multistore",
+ "quick-xml 0.37.5",
  "rsa",
  "serde",
  "serde_json",
@@ -980,8 +978,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1f27fa70820affb7056520372cbf337fa7739056bf6f0e63b4b5870aeb5a8e"
+source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -991,8 +988,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d147130ee410a7f429ab4d8fa1be0f391be43682d3582bf0393e184d705a722a"
+source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
+source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
 dependencies = [
  "async-trait",
  "base64",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
+source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
+source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
 dependencies = [
  "async-trait",
  "base64",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
+source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.4.0"
-source = "git+https://github.com/developmentseed/multistore?rev=2924c27bfeaa83507d73a6bcf8170646ab89c87a#2924c27bfeaa83507d73a6bcf8170646ab89c87a"
+source = "git+https://github.com/developmentseed/multistore?rev=81b24ec1afad4c947a972b8c7f834806d7c0205e#81b24ec1afad4c947a972b8c7f834806d7c0205e"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,15 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
+
+# Track multistore while the consolidated backend-auth work (oidc-provider owning
+# the credential exchange + `BackendCredentials` in core) lands ahead of a
+# crates.io release. Pinned to an exact `rev` (not `branch = "main"`) so builds
+# are reproducible and `cargo update` can't silently float to a newer commit.
+# Drop this patch and bump the versions above once multistore ships.
+[patch.crates-io]
+multistore = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,14 +65,14 @@ web-sys = { version = "0.3", features = [
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
 
-# Track multistore while the consolidated backend-auth work (oidc-provider owning
-# the credential exchange + `BackendCredentials` in core) lands ahead of a
-# crates.io release. Pinned to an exact `rev` (not `branch = "main"`) so builds
-# are reproducible and `cargo update` can't silently float to a newer commit.
-# Drop this patch and bump the versions above once multistore ships.
+# Track multistore ahead of a crates.io release. Pinned to an exact `rev` (not a
+# branch) so builds are reproducible and `cargo update` can't float to a newer
+# commit. The rev is on the `feat/shareable-credential-cache` branch, which adds
+# `Clone` to `OidcCredentialProvider` so the worker can keep one warm credential
+# cache across requests. Drop this patch and bump the versions above once it ships.
 [patch.crates-io]
-multistore = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", rev = "2924c27bfeaa83507d73a6bcf8170646ab89c87a" }
+multistore = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "tests/routing.rs"
 name = "pagination"
 path = "tests/pagination.rs"
 
+[[test]]
+name = "backend_auth"
+path = "tests/backend_auth.rs"
+
 [dependencies]
 # Multistore
 multistore = { version = "0.4.0", features = ["azure"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ path = "tests/backend_auth.rs"
 
 [dependencies]
 # Multistore
-multistore = { version = "0.4.0", features = ["azure"] }
-multistore-oidc-provider = { version = "0.4.0" }
-multistore-path-mapping = { version = "0.4.0" }
-multistore-sts = { version = "0.4.0" }
+multistore = { version = "0.5.1", features = ["azure"] }
+multistore-oidc-provider = { version = "0.5.1" }
+multistore-path-mapping = { version = "0.5.1" }
+multistore-sts = { version = "0.5.1" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -45,7 +45,7 @@ tracing = "0.1"
 # Pulled in transitively via object_store -> rand. getrandom doesn't support
 # wasm32-unknown-unknown unless the `wasm_js` backend is enabled, so opt in here.
 getrandom = { version = "0.4", features = ["wasm_js"] }
-multistore-cf-workers = { version = "0.4.0", features = ["azure"] }
+multistore-cf-workers = { version = "0.5.1", features = ["azure"] }
 # On wasm32-unknown-unknown reqwest selects its browser `fetch` backend by
 # target arch (not a cargo feature), so the default TLS/backend features are
 # unnecessary here. We only use `Client::new()`, `.send()` and `.text()`, none
@@ -64,15 +64,3 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
-
-# Track multistore ahead of a crates.io release. Pinned to an exact `rev` (not a
-# branch) so builds are reproducible and `cargo update` can't float to a newer
-# commit. The rev is on the `feat/shareable-credential-cache` branch, which adds
-# `Clone` to `OidcCredentialProvider` so the worker can keep one warm credential
-# cache across requests. Drop this patch and bump the versions above once it ships.
-[patch.crates-io]
-multistore = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", rev = "81b24ec1afad4c947a972b8c7f834806d7c0205e" }

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -21,8 +21,9 @@ pub(crate) const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
 /// Internally tagged on `type`; defaults to [`Unsigned`](BackendAuth::Unsigned)
 /// when the field is omitted, so existing connections keep issuing unsigned
 /// requests until a role is configured. Unknown `type`s (e.g. the app-side
-/// GCP/Azure workload-identity variants) deserialize to
-/// [`Unsupported`](BackendAuth::Unsupported) instead of failing the request.
+/// GCP/Azure workload-identity variants) are mapped to
+/// [`Unsupported`](BackendAuth::Unsupported) by [`deserialize_lenient`] instead
+/// of failing the request.
 ///
 /// The AWS variant carries only `role_arn`; the audience is the fixed constant
 /// [`AWS_STS_AUDIENCE`] set on the OIDC backend-auth provider, and session
@@ -42,10 +43,9 @@ pub enum BackendAuth {
     },
     /// An authentication type this proxy build does not implement — e.g. the
     /// Source API's `gcp_workload_identity` / `azure_workload_identity` variants,
-    /// scaffolded app-side but without proxy/multistore support yet. Captured via
-    /// `#[serde(other)]` so an unknown `type` deserializes gracefully; treated as
-    /// unsupported (served unsigned, with a warning).
-    #[serde(other)]
+    /// scaffolded app-side but without proxy/multistore support yet. Produced by
+    /// [`deserialize_lenient`], which maps any `authentication` that doesn't parse
+    /// as a known variant to this; `apply_backend_auth` then fails closed on it.
     Unsupported,
 }
 

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -1,0 +1,87 @@
+//! Per-connection backend authentication: the model the Source API reports for a
+//! data connection, and its translation into multistore `backend_options`.
+//!
+//! Kept in its own module — free of wasm-only deps — so it can be unit-tested on
+//! native targets despite the crate's `[lib] test = false`. See
+//! `tests/backend_auth.rs`.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// `aud` claim for the proxy's AWS `AssumeRoleWithWebIdentity` assertions. AWS's
+/// fixed web-identity convention — the value the customer registers their IAM
+/// OIDC provider with and conditions the role trust policy on — so it is constant
+/// across connections. Applied at the OIDC backend-auth provider (see `lib.rs`).
+pub(crate) const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
+
+/// Per-connection backend authentication, as reported by the Source API
+/// (a sibling of `details` on the connection).
+///
+/// Internally tagged on `type`; defaults to [`Unsigned`](BackendAuth::Unsigned)
+/// when the field is omitted, so existing connections keep issuing unsigned
+/// requests until a role is configured. Unknown `type`s (e.g. the app-side
+/// GCP/Azure workload-identity variants) deserialize to
+/// [`Unsupported`](BackendAuth::Unsupported) instead of failing the request.
+///
+/// The AWS variant carries only `role_arn`; the audience is the fixed constant
+/// [`AWS_STS_AUDIENCE`] set on the OIDC backend-auth provider, and session
+/// duration / subject scope may be added later.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BackendAuth {
+    /// Public bucket — issue unsigned requests, no backend credentials.
+    #[default]
+    Unsigned,
+    /// Federate the proxy's OIDC identity into a customer-owned AWS role via
+    /// `AssumeRoleWithWebIdentity`, signing backend requests with the resulting
+    /// temporary credentials. (S3 only for now.)
+    S3WebIdentityRole {
+        /// ARN of the IAM role the proxy assumes for this connection.
+        role_arn: String,
+    },
+    /// An authentication type this proxy build does not implement — e.g. the
+    /// Source API's `gcp_workload_identity` / `azure_workload_identity` variants,
+    /// scaffolded app-side but without proxy/multistore support yet. Captured via
+    /// `#[serde(other)]` so an unknown `type` deserializes gracefully; treated as
+    /// unsupported (served unsigned, with a warning).
+    #[serde(other)]
+    Unsupported,
+}
+
+/// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
+///
+/// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
+///   issues an unsigned request to a public bucket.
+/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
+///   a per-connection subject (`scv1:conn:{id}`) to multistore's OIDC backend-auth
+///   middleware (wired in `lib.rs`), which mints the assertion (with the fixed AWS
+///   audience set on the provider), exchanges it at AWS STS, and injects the
+///   temporary credentials — clearing `skip_signature` so the request is signed.
+/// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it serves
+///   unsigned (a private backend then rejects the request).
+pub(crate) fn apply_backend_auth(
+    auth: &BackendAuth,
+    connection_id: &str,
+    options: &mut HashMap<String, String>,
+) {
+    match auth {
+        BackendAuth::Unsigned => {
+            options.insert("skip_signature".to_string(), "true".to_string());
+        }
+        BackendAuth::S3WebIdentityRole { role_arn } => {
+            options.insert("auth_type".to_string(), "oidc".to_string());
+            options.insert("oidc_role_arn".to_string(), role_arn.clone());
+            options.insert(
+                "oidc_subject".to_string(),
+                format!("scv1:conn:{connection_id}"),
+            );
+        }
+        BackendAuth::Unsupported => {
+            tracing::warn!(
+                connection_id,
+                "unsupported backend authentication type; serving unsigned"
+            );
+            options.insert("skip_signature".to_string(), "true".to_string());
+        }
+    }
+}

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -48,6 +48,25 @@ pub enum BackendAuth {
     Unsupported,
 }
 
+/// Lenient `deserialize_with` for a connection's `authentication` field.
+///
+/// A *present* value that doesn't parse as a known [`BackendAuth`] — unknown
+/// `type`, missing `role_arn`, wrong shape — becomes [`Unsupported`], and `null`
+/// becomes [`Unsigned`]. This keeps a single malformed `authentication` from
+/// failing deserialization of the *entire* data-connection list, which the proxy
+/// parses in one `serde_json::from_str`. An *absent* field is handled by
+/// `#[serde(default)]` and never reaches this function.
+pub(crate) fn deserialize_lenient<'de, D>(deserializer: D) -> Result<BackendAuth, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(BackendAuth::Unsigned);
+    }
+    Ok(serde_json::from_value(value).unwrap_or(BackendAuth::Unsupported))
+}
+
 /// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
 ///
 /// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -5,6 +5,7 @@
 //! native targets despite the crate's `[lib] test = false`. See
 //! `tests/backend_auth.rs`.
 
+use multistore::error::ProxyError;
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -76,13 +77,14 @@ where
 ///   middleware (wired in `lib.rs`), which mints the assertion (with the fixed AWS
 ///   audience set on the provider), exchanges it at AWS STS, and injects the
 ///   temporary credentials — clearing `skip_signature` so the request is signed.
-/// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it serves
-///   unsigned (a private backend then rejects the request).
+/// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it **fails
+///   closed** with [`ProxyError::BackendAuthError`] rather than silently serving
+///   unsigned.
 pub(crate) fn apply_backend_auth(
     auth: &BackendAuth,
     connection_id: &str,
     options: &mut HashMap<String, String>,
-) {
+) -> Result<(), ProxyError> {
     match auth {
         BackendAuth::Unsigned => {
             options.insert("skip_signature".to_string(), "true".to_string());
@@ -95,12 +97,15 @@ pub(crate) fn apply_backend_auth(
                 format!("scv1:conn:{connection_id}"),
             );
         }
+        // Fail closed: a scheme we can't fulfill (the app-side GCP/Azure
+        // workload-identity variants, or a malformed `authentication`) must not
+        // fall back to unsigned — that could expose an anonymously-readable
+        // backend. Deny so the misconfiguration surfaces explicitly.
         BackendAuth::Unsupported => {
-            tracing::warn!(
-                connection_id,
-                "unsupported backend authentication type; serving unsigned"
-            );
-            options.insert("skip_signature".to_string(), "true".to_string());
+            return Err(ProxyError::BackendAuthError(format!(
+                "connection {connection_id}: unsupported backend authentication type"
+            )));
         }
     }
+    Ok(())
 }

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -88,6 +88,8 @@ where
 
 /// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
 ///
+/// `provider` is the resolved backend type (`s3`/`az`/`gcs`).
+///
 /// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
 ///   issues an unsigned request to a public bucket.
 /// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
@@ -95,17 +97,35 @@ where
 ///   middleware (wired in `lib.rs`), which mints the assertion (with the fixed AWS
 ///   audience set on the provider), exchanges it at AWS STS, and injects the
 ///   temporary credentials — clearing `skip_signature` so the request is signed.
+///   Restricted to `s3` providers (STS credentials only sign S3 requests).
 /// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it **fails
 ///   closed** with [`ProxyError::BackendAuthError`] rather than silently serving
 ///   unsigned.
+///
+/// On failure the error carries a short, client-safe code (`ProviderMismatch`,
+/// `UnsupportedAuthType`) — surfaced to the caller verbatim by
+/// [`ProxyError::safe_message`] — while the connection-specific detail is logged
+/// for operators rather than leaked in the response.
 pub(crate) fn apply_backend_auth(
     auth: &BackendAuth,
     connection_id: &str,
+    provider: &str,
     options: &mut HashMap<String, String>,
 ) -> Result<(), ProxyError> {
     match auth {
         BackendAuth::Unsigned => {
             options.insert("skip_signature".to_string(), "true".to_string());
+        }
+        // STS credentials only sign S3 requests. Fail clean if the API ever pairs
+        // this with a non-S3 provider, rather than injecting AWS options into an
+        // Azure/GCS request that would fail opaquely downstream.
+        BackendAuth::S3WebIdentityRole { .. } if provider != "s3" => {
+            tracing::warn!(
+                connection_id,
+                provider,
+                "s3_web_identity_role on a non-s3 connection",
+            );
+            return Err(ProxyError::BackendAuthError("ProviderMismatch".into()));
         }
         BackendAuth::S3WebIdentityRole { role_arn } => {
             options.insert("auth_type".to_string(), "oidc".to_string());
@@ -120,9 +140,8 @@ pub(crate) fn apply_backend_auth(
         // fall back to unsigned — that could expose an anonymously-readable
         // backend. Deny so the misconfiguration surfaces explicitly.
         BackendAuth::Unsupported => {
-            return Err(ProxyError::BackendAuthError(format!(
-                "connection {connection_id}: unsupported backend authentication type"
-            )));
+            tracing::warn!(connection_id, "unsupported backend authentication type");
+            return Err(ProxyError::BackendAuthError("UnsupportedAuthType".into()));
         }
     }
     Ok(())

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -69,6 +69,12 @@ impl BackendAuth {
 /// failing deserialization of the *entire* data-connection list, which the proxy
 /// parses in one `serde_json::from_str`. An *absent* field is handled by
 /// `#[serde(default)]` and never reaches this function.
+///
+/// Deliberately JSON-only: it buffers into a `serde_json::Value` to
+/// attempt-then-degrade, which is exact for serde_json's own data model. The sole
+/// caller is the data-connection list (always JSON from the Source API). If this
+/// is ever reused with a non-JSON deserializer (TOML, etc.), the buffer round-trip
+/// could shift types; switch to a `try_from` on `BackendAuth` then.
 pub(crate) fn deserialize_lenient<'de, D>(deserializer: D) -> Result<BackendAuth, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/src/backend_auth.rs
+++ b/src/backend_auth.rs
@@ -49,6 +49,18 @@ pub enum BackendAuth {
     Unsupported,
 }
 
+impl BackendAuth {
+    /// Short, stable label for logs/spans (no secrets — the role ARN is not
+    /// included).
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            BackendAuth::Unsigned => "unsigned",
+            BackendAuth::S3WebIdentityRole { .. } => "s3_web_identity_role",
+            BackendAuth::Unsupported => "unsupported",
+        }
+    }
+}
+
 /// Lenient `deserialize_with` for a connection's `authentication` field.
 ///
 /// A *present* value that doesn't parse as a known [`BackendAuth`] — unknown

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,8 +25,10 @@ const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
 /// Product metadata (`/api/v1/products/{account}/{product}`).
 const PRODUCT_CACHE_SECS: u32 = 300; // 5 minutes
 
-/// Data connections list (`/api/v1/data-connections`).
-const DATA_CONNECTIONS_CACHE_SECS: u32 = 1800; // 30 minutes
+/// A single data connection (`/api/v1/data-connections/{id}`). Short to match
+/// product metadata: a per-id response is subject-authorized, so the TTL is an
+/// authorization-revocation lag, not just a freshness knob.
+const DATA_CONNECTION_CACHE_SECS: u32 = 300; // 5 minutes
 
 /// Product list for an account (`/api/v1/products/{account}`).
 const PRODUCT_LIST_CACHE_SECS: u32 = 60; // 1 minute
@@ -56,34 +58,37 @@ pub async fn get_or_fetch_product(
         api_auth,
         request_id,
         subject,
-        false,
     )
     .await
 }
 
-/// Fetch all data connections, cached for `DATA_CONNECTIONS_CACHE_SECS`.
+/// Fetch a single data connection by id, cached for `DATA_CONNECTION_CACHE_SECS`.
 ///
-/// Pass `force_refresh = true` to bypass the cached copy and refresh it — used
-/// when a product references a connection missing from the cached list (e.g. one
-/// created after the list cache was filled) so it resolves without waiting out
-/// the TTL.
-pub async fn get_or_fetch_data_connections(
+/// Resolving by id (rather than scanning a cached full list) lets the
+/// subject-scoped Source API authorize this exact connection: a caller not
+/// entitled to it gets 404/403, surfaced as `BucketNotFound` / `AccessDenied`.
+/// A just-created connection resolves on first reference — there is no stale
+/// list to fall behind, so no force-refresh dance is needed.
+pub async fn get_or_fetch_data_connection(
     api_base_url: &str,
+    connection_id: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
     subject: Option<&str>,
-    force_refresh: bool,
-) -> Result<Vec<DataConnection>, ProxyError> {
-    let api_url = format!("{}/api/v1/data-connections", api_base_url);
+) -> Result<DataConnection, ProxyError> {
+    let api_url = format!(
+        "{}/api/v1/data-connections/{}",
+        api_base_url,
+        utf8_percent_encode(connection_id, PATH_SEGMENT),
+    );
     let cache_key = cache_key_with_subject(&api_url, subject);
     cached_fetch(
         &cache_key,
         &api_url,
-        DATA_CONNECTIONS_CACHE_SECS,
+        DATA_CONNECTION_CACHE_SECS,
         api_auth,
         request_id,
         subject,
-        force_refresh,
     )
     .await
 }
@@ -109,7 +114,6 @@ pub async fn get_or_fetch_product_list(
         api_auth,
         request_id,
         subject,
-        false,
     )
     .await
 }
@@ -142,9 +146,6 @@ fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
 /// Generic cache-or-fetch: check the Cache API, return cached JSON on hit,
 /// otherwise fetch from `api_url`, store in cache with the given TTL, and
 /// return the deserialized result.
-///
-/// `force_refresh` skips the cache read and forces a fresh fetch, still writing
-/// the result back so the cached copy is refreshed for later callers.
 async fn cached_fetch<T: serde::de::DeserializeOwned>(
     cache_key: &str,
     api_url: &str,
@@ -152,7 +153,6 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     api_auth: &crate::ApiAuth,
     request_id: &str,
     subject: Option<&str>,
-    force_refresh: bool,
 ) -> Result<T, ProxyError> {
     let span = tracing::info_span!(
         "cached_fetch",
@@ -165,20 +165,18 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     let cache = worker::Cache::default();
 
     // ── Cache hit ──────────────────────────────────────────────
-    if !force_refresh {
-        if let Some(mut cached_resp) = cache
-            .get(cache_key, false)
+    if let Some(mut cached_resp) = cache
+        .get(cache_key, false)
+        .await
+        .map_err(|e| ProxyError::Internal(format!("cache get failed: {}", e)))?
+    {
+        span.record("cache_hit", true);
+        let text = cached_resp
+            .text()
             .await
-            .map_err(|e| ProxyError::Internal(format!("cache get failed: {}", e)))?
-        {
-            span.record("cache_hit", true);
-            let text = cached_resp
-                .text()
-                .await
-                .map_err(|e| ProxyError::Internal(format!("cache body read failed: {}", e)))?;
-            return serde_json::from_str(&text)
-                .map_err(|e| ProxyError::Internal(format!("cache JSON parse failed: {}", e)));
-        }
+            .map_err(|e| ProxyError::Internal(format!("cache body read failed: {}", e)))?;
+        return serde_json::from_str(&text)
+            .map_err(|e| ProxyError::Internal(format!("cache JSON parse failed: {}", e)));
     }
 
     // ── Cache miss — fetch from API ────────────────────────────

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -56,16 +56,23 @@ pub async fn get_or_fetch_product(
         api_auth,
         request_id,
         subject,
+        false,
     )
     .await
 }
 
 /// Fetch all data connections, cached for `DATA_CONNECTIONS_CACHE_SECS`.
+///
+/// Pass `force_refresh = true` to bypass the cached copy and refresh it — used
+/// when a product references a connection missing from the cached list (e.g. one
+/// created after the list cache was filled) so it resolves without waiting out
+/// the TTL.
 pub async fn get_or_fetch_data_connections(
     api_base_url: &str,
     api_auth: &crate::ApiAuth,
     request_id: &str,
     subject: Option<&str>,
+    force_refresh: bool,
 ) -> Result<Vec<DataConnection>, ProxyError> {
     let api_url = format!("{}/api/v1/data-connections", api_base_url);
     let cache_key = cache_key_with_subject(&api_url, subject);
@@ -76,6 +83,7 @@ pub async fn get_or_fetch_data_connections(
         api_auth,
         request_id,
         subject,
+        force_refresh,
     )
     .await
 }
@@ -101,6 +109,7 @@ pub async fn get_or_fetch_product_list(
         api_auth,
         request_id,
         subject,
+        false,
     )
     .await
 }
@@ -132,6 +141,9 @@ fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
 /// Generic cache-or-fetch: check the Cache API, return cached JSON on hit,
 /// otherwise fetch from `api_url`, store in cache with the given TTL, and
 /// return the deserialized result.
+///
+/// `force_refresh` skips the cache read and forces a fresh fetch, still writing
+/// the result back so the cached copy is refreshed for later callers.
 async fn cached_fetch<T: serde::de::DeserializeOwned>(
     cache_key: &str,
     api_url: &str,
@@ -139,6 +151,7 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     api_auth: &crate::ApiAuth,
     request_id: &str,
     subject: Option<&str>,
+    force_refresh: bool,
 ) -> Result<T, ProxyError> {
     let span = tracing::info_span!(
         "cached_fetch",
@@ -151,18 +164,20 @@ async fn cached_fetch<T: serde::de::DeserializeOwned>(
     let cache = worker::Cache::default();
 
     // ── Cache hit ──────────────────────────────────────────────
-    if let Some(mut cached_resp) = cache
-        .get(cache_key, false)
-        .await
-        .map_err(|e| ProxyError::Internal(format!("cache get failed: {}", e)))?
-    {
-        span.record("cache_hit", true);
-        let text = cached_resp
-            .text()
+    if !force_refresh {
+        if let Some(mut cached_resp) = cache
+            .get(cache_key, false)
             .await
-            .map_err(|e| ProxyError::Internal(format!("cache body read failed: {}", e)))?;
-        return serde_json::from_str(&text)
-            .map_err(|e| ProxyError::Internal(format!("cache JSON parse failed: {}", e)));
+            .map_err(|e| ProxyError::Internal(format!("cache get failed: {}", e)))?
+        {
+            span.record("cache_hit", true);
+            let text = cached_resp
+                .text()
+                .await
+                .map_err(|e| ProxyError::Internal(format!("cache body read failed: {}", e)))?;
+            return serde_json::from_str(&text)
+                .map_err(|e| ProxyError::Internal(format!("cache JSON parse failed: {}", e)));
+        }
     }
 
     // ── Cache miss — fetch from API ────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,11 @@ impl HttpExchange for FetchHttpExchange {
             .send()
             .await
             .map_err(|e| OidcProviderError::HttpError(e.to_string()))?;
+        // Intentionally NOT checking the HTTP status / calling
+        // `error_for_status()`: AWS STS returns its `<ErrorResponse>` XML in the
+        // body on 4xx/5xx, and multistore's `parse_response` reads the error
+        // (code + message) out of that body. Discarding it on a non-2xx would
+        // lose the diagnostic and the precise ProxyError mapping.
         resp.text()
             .await
             .map_err(|e| OidcProviderError::HttpError(e.to_string()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ use multistore_cf_workers::{
     collect_js_body, GatewayResponseExt, NoopCredentialRegistry, RequestParts, WorkerBackend,
     WorkerSubscriber,
 };
+use multistore_oidc_provider::backend_auth::{AwsBackendAuth, MaybeOidcAuth};
 use multistore_oidc_provider::route_handler::OidcRouterExt;
+use multistore_oidc_provider::{HttpExchange, OidcCredentialProvider, OidcProviderError};
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use multistore_sts::jwks::JwksCache;
 use multistore_sts::route_handler::StsRouterExt;
@@ -49,6 +51,33 @@ fn jwks_cache() -> JwksCache {
     JWKS_CACHE
         .get_or_init(|| JwksCache::new(http_client(), std::time::Duration::from_secs(900)))
         .clone()
+}
+
+/// [`HttpExchange`] for outbound STS calls, backed by the shared reqwest client
+/// (reqwest wraps `web_sys::fetch` on wasm). This is what lets the OIDC
+/// backend-auth middleware POST `AssumeRoleWithWebIdentity` to AWS STS.
+#[derive(Clone)]
+struct FetchHttpExchange {
+    client: reqwest::Client,
+}
+
+impl HttpExchange for FetchHttpExchange {
+    async fn post_form(
+        &self,
+        url: &str,
+        form: &[(&str, &str)],
+    ) -> std::result::Result<String, OidcProviderError> {
+        let resp = self
+            .client
+            .post(url)
+            .form(form)
+            .send()
+            .await
+            .map_err(|e| OidcProviderError::HttpError(e.to_string()))?;
+        resp.text()
+            .await
+            .map_err(|e| OidcProviderError::HttpError(e.to_string()))
+    }
 }
 
 #[event(fetch)]
@@ -177,12 +206,28 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         AccountListHandler::new(registry.clone(), &mapping),
     );
 
+    // ── Backend federation middleware ─────────────────────────────
+    // For a connection resolved with auth_type=oidc, mint the proxy's OIDC
+    // assertion, exchange it at AWS STS (AssumeRoleWithWebIdentity) over fetch,
+    // and inject the temporary credentials so the backend request is signed.
+    // A no-op for connections without auth_type=oidc (i.e. unsigned/public).
+    let backend_auth =
+        MaybeOidcAuth::Enabled(Box::new(AwsBackendAuth::new(OidcCredentialProvider::new(
+            config.oidc.signer.clone(),
+            FetchHttpExchange {
+                client: http_client(),
+            },
+            config.oidc.issuer.clone(),
+            registry::AWS_STS_AUDIENCE.to_string(),
+        ))));
+
     let gateway = ProxyGateway::new(
         WorkerBackend,
         MappedRegistry::new(registry, mapping.clone()),
         NoopCredentialRegistry,
         None,
     )
+    .with_middleware(backend_auth)
     .with_router(router)
     .with_debug_errors(max_level >= tracing::Level::DEBUG)
     .with_credential_resolver(config.session_token_key.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod analytics;
 mod auth;
+mod backend_auth;
 mod cache;
 mod config;
 mod handlers;
@@ -218,7 +219,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
                 client: http_client(),
             },
             config.oidc.issuer.clone(),
-            registry::AWS_STS_AUDIENCE.to_string(),
+            crate::backend_auth::AWS_STS_AUDIENCE.to_string(),
         ))));
 
     let gateway = ProxyGateway::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,13 @@ impl HttpExchange for FetchHttpExchange {
     }
 }
 
+/// Isolate-shared OIDC credential provider for backend federation. The gateway
+/// (and its middleware) are rebuilt per request, but the provider — and its
+/// credential cache — must persist so the proxy doesn't re-mint a JWT and re-run
+/// `AssumeRoleWithWebIdentity` on every request to the same role. Initialized
+/// from the first request's signing config, which is constant for the isolate.
+static OIDC_PROVIDER: OnceLock<OidcCredentialProvider<FetchHttpExchange>> = OnceLock::new();
+
 #[event(fetch)]
 async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys::Response> {
     console_error_panic_hook::set_once();
@@ -212,15 +219,21 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // assertion, exchange it at AWS STS (AssumeRoleWithWebIdentity) over fetch,
     // and inject the temporary credentials so the backend request is signed.
     // A no-op for connections without auth_type=oidc (i.e. unsigned/public).
-    let backend_auth =
-        MaybeOidcAuth::Enabled(Box::new(AwsBackendAuth::new(OidcCredentialProvider::new(
-            config.oidc.signer.clone(),
-            FetchHttpExchange {
-                client: http_client(),
-            },
-            config.oidc.issuer.clone(),
-            crate::backend_auth::AWS_STS_AUDIENCE.to_string(),
-        ))));
+    // Reuse the isolate-shared provider so its credential cache stays warm across
+    // requests; `clone()` is cheap and shares that cache.
+    let provider = OIDC_PROVIDER
+        .get_or_init(|| {
+            OidcCredentialProvider::new(
+                config.oidc.signer.clone(),
+                FetchHttpExchange {
+                    client: http_client(),
+                },
+                config.oidc.issuer.clone(),
+                crate::backend_auth::AWS_STS_AUDIENCE.to_string(),
+            )
+        })
+        .clone();
+    let backend_auth = MaybeOidcAuth::Enabled(Box::new(AwsBackendAuth::new(provider)));
 
     let gateway = ProxyGateway::new(
         WorkerBackend,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -224,17 +224,17 @@ async fn resolve_product(
 /// web-identity convention — the value the customer registers their IAM OIDC
 /// provider with and conditions the role trust policy on — so it is constant
 /// across connections rather than per-connection config.
-const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
+pub(crate) const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
 
 /// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
 ///
 /// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
 ///   issues an unsigned request to a public bucket.
-/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN, a
-///   per-connection subject (`scv1:conn:{id}`), and the fixed AWS audience to
-///   multistore's OIDC backend-auth middleware, which mints the assertion,
-///   exchanges it at AWS STS, and injects the temporary credentials — clearing
-///   `skip_signature` so the request is signed.
+/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
+///   a per-connection subject (`scv1:conn:{id}`) to multistore's OIDC backend-auth
+///   middleware, which mints the assertion (the fixed AWS audience comes from the
+///   provider), exchanges it at AWS STS, and injects the temporary credentials —
+///   clearing `skip_signature` so the request is signed.
 /// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it serves
 ///   unsigned (a private backend then rejects the request).
 ///
@@ -258,10 +258,6 @@ fn apply_backend_auth(
                 "oidc_subject".to_string(),
                 format!("scv1:conn:{connection_id}"),
             );
-            // The audience is the fixed AWS web-identity value for every
-            // connection (recorded per bucket so each cloud can carry its own
-            // once multi-cloud federation lands).
-            options.insert("oidc_audience".to_string(), AWS_STS_AUDIENCE.to_string());
         }
         // Unknown/unsupported auth type — e.g. the app-side `gcp_workload_identity`
         // / `azure_workload_identity` variants, which have no proxy/multistore
@@ -358,8 +354,8 @@ pub struct DataConnectionDetails {
 /// [`Unsupported`](BackendAuth::Unsupported) instead of failing the request.
 ///
 /// The AWS variant carries only `role_arn`; the audience is a fixed constant
-/// ([`AWS_STS_AUDIENCE`]) applied in [`apply_backend_auth`], and session duration
-/// / subject scope may be added later.
+/// ([`AWS_STS_AUDIENCE`]) set on the OIDC backend-auth provider, and session
+/// duration / subject scope may be added later.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BackendAuth {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -182,10 +182,14 @@ async fn resolve_product(
         _ => {}
     }
 
-    // TODO: For authenticated users, provide real backend credentials so that
-    // write operations can be forwarded to the storage backend. Currently all
-    // requests use anonymous/unsigned access, so writes will fail at the backend.
-    backend_options.insert("skip_signature".to_string(), "true".to_string());
+    // Backend authentication: unsigned (public) by default, or federate the
+    // proxy's OIDC identity into the connection's role. Connections omit
+    // `authentication` until a role is configured, so this stays unsigned today.
+    apply_backend_auth(
+        &connection.details.authentication,
+        &connection.data_connection_id,
+        &mut backend_options,
+    );
 
     // 5. Build prefix: connection.base_prefix + mirror.prefix
     let base_prefix = connection.details.base_prefix.as_deref().unwrap_or("");
@@ -214,6 +218,40 @@ async fn resolve_product(
     );
 
     Ok(config)
+}
+
+/// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
+///
+/// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
+///   issues an unsigned request to a public bucket.
+/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
+///   a per-connection subject (`scv1:conn:{id}`) to multistore's OIDC backend-auth
+///   middleware, which mints the assertion, exchanges it at AWS STS, and injects
+///   the temporary credentials — clearing `skip_signature` so the request is
+///   signed.
+///
+/// NOTE: the federated path only takes effect once the `MaybeOidcAuth` middleware
+/// is wired into dispatch (next step). Until then the Source API sends no
+/// `authentication`, so every connection takes the `Unsigned` branch and behavior
+/// is unchanged.
+fn apply_backend_auth(
+    auth: &BackendAuth,
+    connection_id: &str,
+    options: &mut HashMap<String, String>,
+) {
+    match auth {
+        BackendAuth::Unsigned => {
+            options.insert("skip_signature".to_string(), "true".to_string());
+        }
+        BackendAuth::S3WebIdentityRole { role_arn } => {
+            options.insert("auth_type".to_string(), "oidc".to_string());
+            options.insert("oidc_role_arn".to_string(), role_arn.clone());
+            options.insert(
+                "oidc_subject".to_string(),
+                format!("scv1:conn:{connection_id}"),
+            );
+        }
+    }
 }
 
 // ── API response types ─────────────────────────────────────────────
@@ -278,6 +316,35 @@ pub struct DataConnectionDetails {
     pub base_prefix: Option<String>,
     pub account_name: Option<String>,
     pub container_name: Option<String>,
+    /// How the proxy authenticates to this connection's backend. Absent in the
+    /// API response → [`BackendAuth::Unsigned`] (public bucket), preserving the
+    /// pre-federation behavior for every connection that hasn't opted in.
+    #[serde(default)]
+    pub authentication: BackendAuth,
+}
+
+/// Per-connection backend authentication, as reported by the Source API.
+///
+/// Internally tagged on `type`; defaults to [`Unsigned`](BackendAuth::Unsigned)
+/// when the field is omitted, so existing connections keep issuing unsigned
+/// requests until a role is configured for them.
+///
+/// The federated variant intentionally carries only `role_arn` for now; the
+/// rest of the role contract (audience, session duration, subject scope) will be
+/// added here as the backend-auth middleware that consumes them is wired in.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BackendAuth {
+    /// Public bucket — issue unsigned requests, no backend credentials.
+    #[default]
+    Unsigned,
+    /// Federate the proxy's OIDC identity into a customer-owned AWS role via
+    /// `AssumeRoleWithWebIdentity`, signing backend requests with the resulting
+    /// temporary credentials. (S3 only for now.)
+    S3WebIdentityRole {
+        /// ARN of the IAM role the proxy assumes for this connection.
+        role_arn: String,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -127,49 +127,17 @@ async fn resolve_product(
             ProxyError::BucketNotFound(format!("no mirrors for {}/{}", account, product))
         })?;
 
-    // 3. Fetch data connections to resolve the actual bucket
-    let mut connections = crate::cache::get_or_fetch_data_connections(
+    // 3. Fetch the referenced connection by id, so the subject-scoped API
+    // authorizes this exact resource (404/403 → BucketNotFound/AccessDenied)
+    // instead of the proxy resolving it out of an over-broad cached list.
+    let connection = crate::cache::get_or_fetch_data_connection(
         api_base_url,
+        &mirror.connection_id,
         api_auth,
         request_id,
         subject,
-        false,
     )
     .await?;
-
-    // A referenced connection missing from the cached list usually means it was
-    // created after the list cache was filled (up to a 30-min TTL). Treat that
-    // as a cache miss: refetch once, bypassing the cache, before giving up.
-    // Negative results aren't cached, so a product permanently referencing a bogus
-    // connection refetches the full list on every request — fine, that product is
-    // itself a misconfiguration.
-    if !connections
-        .iter()
-        .any(|c| c.data_connection_id == mirror.connection_id)
-    {
-        tracing::debug!(
-            connection_id = %mirror.connection_id,
-            "connection absent from cached list; refetching",
-        );
-        connections = crate::cache::get_or_fetch_data_connections(
-            api_base_url,
-            api_auth,
-            request_id,
-            subject,
-            true,
-        )
-        .await?;
-    }
-
-    let connection = connections
-        .iter()
-        .find(|c| c.data_connection_id == mirror.connection_id)
-        .ok_or_else(|| {
-            ProxyError::Internal(format!(
-                "data connection '{}' not found",
-                mirror.connection_id
-            ))
-        })?;
 
     // 4. Build BucketConfig
     let backend_type = match connection.details.provider.as_str() {
@@ -215,10 +183,10 @@ async fn resolve_product(
     // proxy's OIDC identity into the connection's role.
     //
     // The confused-deputy guard is upstream: the subject-scoped Source API
-    // fetches above (get_or_fetch_product / get_or_fetch_data_connections, keyed
-    // on the caller's principal) only return products/connections this caller is
-    // authorized for — so reaching here means the caller is already cleared for
-    // this connection's backend. Federation does not re-authorize.
+    // fetches above (get_or_fetch_product / get_or_fetch_data_connection, keyed
+    // on the caller's principal) only return the product/connection this caller
+    // is authorized for — so reaching here means the caller is already cleared
+    // for this connection's backend. Federation does not re-authorize.
     //
     // This ordering is enforced by data dependency, not just statement order:
     // apply_backend_auth needs `connection`, which only exists once the
@@ -314,7 +282,7 @@ pub struct DataConnection {
     /// How the proxy authenticates to this connection's backend. A sibling of
     /// `details`, matching the Source API's `DataConnection` shape. Absent →
     /// [`BackendAuth::Unsigned`] (public bucket); a present-but-malformed value
-    /// becomes `Unsupported` rather than failing the whole list (see
+    /// becomes `Unsupported` (fail closed) rather than erroring the fetch (see
     /// [`deserialize_lenient`](crate::backend_auth::deserialize_lenient)).
     #[serde(default, deserialize_with = "crate::backend_auth::deserialize_lenient")]
     pub authentication: BackendAuth,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -186,8 +186,13 @@ async fn resolve_product(
     }
 
     // Backend authentication: unsigned (public) by default, or federate the
-    // proxy's OIDC identity into the connection's role. Connections omit
-    // `authentication` until a role is configured, so this stays unsigned today.
+    // proxy's OIDC identity into the connection's role.
+    //
+    // The confused-deputy guard is upstream: the subject-scoped Source API
+    // fetches above (get_or_fetch_product / get_or_fetch_data_connections, keyed
+    // on the caller's principal) only return products/connections this caller is
+    // authorized for — so reaching here means the caller is already cleared for
+    // this connection's backend. Federation does not re-authorize.
     span.record("auth_type", connection.authentication.kind());
     apply_backend_auth(
         &connection.authentication,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -186,7 +186,7 @@ async fn resolve_product(
     // proxy's OIDC identity into the connection's role. Connections omit
     // `authentication` until a role is configured, so this stays unsigned today.
     apply_backend_auth(
-        &connection.details.authentication,
+        &connection.authentication,
         &connection.data_connection_id,
         &mut backend_options,
     );
@@ -220,20 +220,28 @@ async fn resolve_product(
     Ok(config)
 }
 
+/// `aud` claim for AWS `AssumeRoleWithWebIdentity` assertions. This is AWS's
+/// web-identity convention — the value the customer registers their IAM OIDC
+/// provider with and conditions the role trust policy on — so it is constant
+/// across connections rather than per-connection config.
+const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
+
 /// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
 ///
 /// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
 ///   issues an unsigned request to a public bucket.
-/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
-///   a per-connection subject (`scv1:conn:{id}`) to multistore's OIDC backend-auth
-///   middleware, which mints the assertion, exchanges it at AWS STS, and injects
-///   the temporary credentials — clearing `skip_signature` so the request is
-///   signed.
+/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN, a
+///   per-connection subject (`scv1:conn:{id}`), and the fixed AWS audience to
+///   multistore's OIDC backend-auth middleware, which mints the assertion,
+///   exchanges it at AWS STS, and injects the temporary credentials — clearing
+///   `skip_signature` so the request is signed.
+/// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it serves
+///   unsigned (a private backend then rejects the request).
 ///
 /// NOTE: the federated path only takes effect once the `MaybeOidcAuth` middleware
-/// is wired into dispatch (next step). Until then the Source API sends no
-/// `authentication`, so every connection takes the `Unsigned` branch and behavior
-/// is unchanged.
+/// is wired into dispatch (next step); multistore currently also takes the
+/// audience at provider construction. Until both land the federated branches are
+/// inert, but the option set is what the middleware will consume.
 fn apply_backend_auth(
     auth: &BackendAuth,
     connection_id: &str,
@@ -250,6 +258,22 @@ fn apply_backend_auth(
                 "oidc_subject".to_string(),
                 format!("scv1:conn:{connection_id}"),
             );
+            // The audience is the fixed AWS web-identity value for every
+            // connection (recorded per bucket so each cloud can carry its own
+            // once multi-cloud federation lands).
+            options.insert("oidc_audience".to_string(), AWS_STS_AUDIENCE.to_string());
+        }
+        // Unknown/unsupported auth type — e.g. the app-side `gcp_workload_identity`
+        // / `azure_workload_identity` variants, which have no proxy/multistore
+        // support yet. Don't sign with a scheme we can't fulfill: serve unsigned so
+        // public buckets still work; a private backend rejects the unsigned request,
+        // surfacing the misconfiguration instead of silently mis-signing.
+        BackendAuth::Unsupported => {
+            tracing::warn!(
+                connection_id,
+                "unsupported backend authentication type; serving unsigned"
+            );
+            options.insert("skip_signature".to_string(), "true".to_string());
         }
     }
 }
@@ -306,6 +330,12 @@ pub struct SourceProductMirror {
 pub struct DataConnection {
     pub data_connection_id: String,
     pub details: DataConnectionDetails,
+    /// How the proxy authenticates to this connection's backend. A sibling of
+    /// `details`, matching the Source API's `DataConnection` shape. Absent in the
+    /// API response → [`BackendAuth::Unsigned`] (public bucket), preserving the
+    /// pre-federation behavior for every connection that hasn't opted in.
+    #[serde(default)]
+    pub authentication: BackendAuth,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -316,22 +346,20 @@ pub struct DataConnectionDetails {
     pub base_prefix: Option<String>,
     pub account_name: Option<String>,
     pub container_name: Option<String>,
-    /// How the proxy authenticates to this connection's backend. Absent in the
-    /// API response → [`BackendAuth::Unsigned`] (public bucket), preserving the
-    /// pre-federation behavior for every connection that hasn't opted in.
-    #[serde(default)]
-    pub authentication: BackendAuth,
 }
 
-/// Per-connection backend authentication, as reported by the Source API.
+/// Per-connection backend authentication, as reported by the Source API
+/// (a sibling of `details` on the connection).
 ///
 /// Internally tagged on `type`; defaults to [`Unsigned`](BackendAuth::Unsigned)
 /// when the field is omitted, so existing connections keep issuing unsigned
-/// requests until a role is configured for them.
+/// requests until a role is configured for them. Unknown `type`s (e.g. the
+/// app-side GCP/Azure workload-identity variants) deserialize to
+/// [`Unsupported`](BackendAuth::Unsupported) instead of failing the request.
 ///
-/// The federated variant intentionally carries only `role_arn` for now; the
-/// rest of the role contract (audience, session duration, subject scope) will be
-/// added here as the backend-auth middleware that consumes them is wired in.
+/// The AWS variant carries only `role_arn`; the audience is a fixed constant
+/// ([`AWS_STS_AUDIENCE`]) applied in [`apply_backend_auth`], and session duration
+/// / subject scope may be added later.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BackendAuth {
@@ -345,6 +373,13 @@ pub enum BackendAuth {
         /// ARN of the IAM role the proxy assumes for this connection.
         role_arn: String,
     },
+    /// An authentication type this proxy build does not implement — e.g. the
+    /// Source API's `gcp_workload_identity` / `azure_workload_identity` variants,
+    /// scaffolded app-side but without proxy/multistore support yet. Captured via
+    /// `#[serde(other)]` so an unknown `type` deserializes gracefully; treated as
+    /// unsupported (served unsigned, with a warning).
+    #[serde(other)]
+    Unsupported,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -104,6 +104,7 @@ async fn resolve_product(
         account = %account,
         product = %product,
         backend_type = tracing::field::Empty,
+        auth_type = tracing::field::Empty,
     );
     let _guard = span.enter();
 
@@ -187,6 +188,7 @@ async fn resolve_product(
     // Backend authentication: unsigned (public) by default, or federate the
     // proxy's OIDC identity into the connection's role. Connections omit
     // `authentication` until a role is configured, so this stays unsigned today.
+    span.record("auth_type", connection.authentication.kind());
     apply_backend_auth(
         &connection.authentication,
         &connection.data_connection_id,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -140,9 +140,9 @@ async fn resolve_product(
     // A referenced connection missing from the cached list usually means it was
     // created after the list cache was filled (up to a 30-min TTL). Treat that
     // as a cache miss: refetch once, bypassing the cache, before giving up.
-    // ponytail: negative results aren't cached, so a product permanently
-    // referencing a bogus connection refetches the full list on every request —
-    // fine, that product is itself a misconfiguration.
+    // Negative results aren't cached, so a product permanently referencing a bogus
+    // connection refetches the full list on every request — fine, that product is
+    // itself a misconfiguration.
     if !connections
         .iter()
         .any(|c| c.data_connection_id == mirror.connection_id)
@@ -219,6 +219,13 @@ async fn resolve_product(
     // on the caller's principal) only return products/connections this caller is
     // authorized for — so reaching here means the caller is already cleared for
     // this connection's backend. Federation does not re-authorize.
+    //
+    // This ordering is enforced by data dependency, not just statement order:
+    // apply_backend_auth needs `connection`, which only exists once the
+    // subject-scoped fetch succeeds. A 403/404 from that fetch propagates via `?`
+    // before we ever get here, so an unauthorized caller can never reach
+    // federation. Guarded end-to-end by tests/test_federation.py's
+    // test_restricted_product_denied_to_anonymous.
     span.record("auth_type", connection.authentication.kind());
     apply_backend_auth(
         &connection.authentication,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -191,7 +191,7 @@ async fn resolve_product(
         &connection.authentication,
         &connection.data_connection_id,
         &mut backend_options,
-    );
+    )?;
 
     // 5. Build prefix: connection.base_prefix + mirror.prefix
     let base_prefix = connection.details.base_prefix.as_deref().unwrap_or("");

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -198,6 +198,7 @@ async fn resolve_product(
     apply_backend_auth(
         &connection.authentication,
         &connection.data_connection_id,
+        &backend_type,
         &mut backend_options,
     )?;
 
@@ -215,6 +216,11 @@ async fn resolve_product(
         name: format!("{}{}{}", account, crate::BUCKET_SEPARATOR, product),
         backend_type,
         backend_prefix,
+        // Proxy-client-facing: Source Cooperative authorizes callers via its own
+        // JWT (enforced upstream at the subject-scoped fetch), not S3 request
+        // signing to the proxy — so the proxy accepts anonymous S3 requests and
+        // does its own authz. Always true, including for private/federated
+        // connections (whose backend auth is handled separately above).
         anonymous_access: true,
         allowed_roles: vec![],
         backend_options,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,6 +7,8 @@ use multistore::types::{BucketConfig, ResolvedIdentity, S3Operation};
 use serde::Deserialize;
 use std::collections::HashMap;
 
+use crate::backend_auth::{apply_backend_auth, BackendAuth};
+
 /// Registry that resolves Source Cooperative products to multistore `BucketConfig`s
 /// by calling the Source Cooperative API.
 #[derive(Clone)]
@@ -220,60 +222,6 @@ async fn resolve_product(
     Ok(config)
 }
 
-/// `aud` claim for AWS `AssumeRoleWithWebIdentity` assertions. This is AWS's
-/// web-identity convention — the value the customer registers their IAM OIDC
-/// provider with and conditions the role trust policy on — so it is constant
-/// across connections rather than per-connection config.
-pub(crate) const AWS_STS_AUDIENCE: &str = "sts.amazonaws.com";
-
-/// Translate a connection's [`BackendAuth`] into multistore `backend_options`.
-///
-/// - [`Unsigned`](BackendAuth::Unsigned) sets `skip_signature` so the proxy
-///   issues an unsigned request to a public bucket.
-/// - [`S3WebIdentityRole`](BackendAuth::S3WebIdentityRole) hands the role ARN and
-///   a per-connection subject (`scv1:conn:{id}`) to multistore's OIDC backend-auth
-///   middleware, which mints the assertion (the fixed AWS audience comes from the
-///   provider), exchanges it at AWS STS, and injects the temporary credentials —
-///   clearing `skip_signature` so the request is signed.
-/// - [`Unsupported`](BackendAuth::Unsupported) can't be fulfilled, so it serves
-///   unsigned (a private backend then rejects the request).
-///
-/// NOTE: the federated path only takes effect once the `MaybeOidcAuth` middleware
-/// is wired into dispatch (next step); multistore currently also takes the
-/// audience at provider construction. Until both land the federated branches are
-/// inert, but the option set is what the middleware will consume.
-fn apply_backend_auth(
-    auth: &BackendAuth,
-    connection_id: &str,
-    options: &mut HashMap<String, String>,
-) {
-    match auth {
-        BackendAuth::Unsigned => {
-            options.insert("skip_signature".to_string(), "true".to_string());
-        }
-        BackendAuth::S3WebIdentityRole { role_arn } => {
-            options.insert("auth_type".to_string(), "oidc".to_string());
-            options.insert("oidc_role_arn".to_string(), role_arn.clone());
-            options.insert(
-                "oidc_subject".to_string(),
-                format!("scv1:conn:{connection_id}"),
-            );
-        }
-        // Unknown/unsupported auth type — e.g. the app-side `gcp_workload_identity`
-        // / `azure_workload_identity` variants, which have no proxy/multistore
-        // support yet. Don't sign with a scheme we can't fulfill: serve unsigned so
-        // public buckets still work; a private backend rejects the unsigned request,
-        // surfacing the misconfiguration instead of silently mis-signing.
-        BackendAuth::Unsupported => {
-            tracing::warn!(
-                connection_id,
-                "unsupported backend authentication type; serving unsigned"
-            );
-            options.insert("skip_signature".to_string(), "true".to_string());
-        }
-    }
-}
-
 // ── API response types ─────────────────────────────────────────────
 
 /// Product visibility, mirroring `ProductVisibility` in the source.coop data
@@ -342,40 +290,6 @@ pub struct DataConnectionDetails {
     pub base_prefix: Option<String>,
     pub account_name: Option<String>,
     pub container_name: Option<String>,
-}
-
-/// Per-connection backend authentication, as reported by the Source API
-/// (a sibling of `details` on the connection).
-///
-/// Internally tagged on `type`; defaults to [`Unsigned`](BackendAuth::Unsigned)
-/// when the field is omitted, so existing connections keep issuing unsigned
-/// requests until a role is configured for them. Unknown `type`s (e.g. the
-/// app-side GCP/Azure workload-identity variants) deserialize to
-/// [`Unsupported`](BackendAuth::Unsupported) instead of failing the request.
-///
-/// The AWS variant carries only `role_arn`; the audience is a fixed constant
-/// ([`AWS_STS_AUDIENCE`]) set on the OIDC backend-auth provider, and session
-/// duration / subject scope may be added later.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum BackendAuth {
-    /// Public bucket — issue unsigned requests, no backend credentials.
-    #[default]
-    Unsigned,
-    /// Federate the proxy's OIDC identity into a customer-owned AWS role via
-    /// `AssumeRoleWithWebIdentity`, signing backend requests with the resulting
-    /// temporary credentials. (S3 only for now.)
-    S3WebIdentityRole {
-        /// ARN of the IAM role the proxy assumes for this connection.
-        role_arn: String,
-    },
-    /// An authentication type this proxy build does not implement — e.g. the
-    /// Source API's `gcp_workload_identity` / `azure_workload_identity` variants,
-    /// scaffolded app-side but without proxy/multistore support yet. Captured via
-    /// `#[serde(other)]` so an unknown `type` deserializes gracefully; treated as
-    /// unsupported (served unsigned, with a warning).
-    #[serde(other)]
-    Unsupported,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -131,9 +131,38 @@ async fn resolve_product(
         })?;
 
     // 3. Fetch data connections to resolve the actual bucket
-    let connections =
-        crate::cache::get_or_fetch_data_connections(api_base_url, api_auth, request_id, subject)
-            .await?;
+    let mut connections = crate::cache::get_or_fetch_data_connections(
+        api_base_url,
+        api_auth,
+        request_id,
+        subject,
+        false,
+    )
+    .await?;
+
+    // A referenced connection missing from the cached list usually means it was
+    // created after the list cache was filled (up to a 30-min TTL). Treat that
+    // as a cache miss: refetch once, bypassing the cache, before giving up.
+    // ponytail: negative results aren't cached, so a product permanently
+    // referencing a bogus connection refetches the full list on every request —
+    // fine, that product is itself a misconfiguration.
+    if !connections
+        .iter()
+        .any(|c| c.data_connection_id == mirror.connection_id)
+    {
+        tracing::debug!(
+            connection_id = %mirror.connection_id,
+            "connection absent from cached list; refetching",
+        );
+        connections = crate::cache::get_or_fetch_data_connections(
+            api_base_url,
+            api_auth,
+            request_id,
+            subject,
+            true,
+        )
+        .await?;
+    }
 
     let connection = connections
         .iter()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -275,10 +275,11 @@ pub struct DataConnection {
     pub data_connection_id: String,
     pub details: DataConnectionDetails,
     /// How the proxy authenticates to this connection's backend. A sibling of
-    /// `details`, matching the Source API's `DataConnection` shape. Absent in the
-    /// API response → [`BackendAuth::Unsigned`] (public bucket), preserving the
-    /// pre-federation behavior for every connection that hasn't opted in.
-    #[serde(default)]
+    /// `details`, matching the Source API's `DataConnection` shape. Absent →
+    /// [`BackendAuth::Unsigned`] (public bucket); a present-but-malformed value
+    /// becomes `Unsupported` rather than failing the whole list (see
+    /// [`deserialize_lenient`](crate::backend_auth::deserialize_lenient)).
+    #[serde(default, deserialize_with = "crate::backend_auth::deserialize_lenient")]
     pub authentication: BackendAuth,
 }
 

--- a/tests/backend_auth.rs
+++ b/tests/backend_auth.rs
@@ -30,6 +30,54 @@ fn deserializes_web_identity_role() {
     );
 }
 
+// ── lenient field deserialization (one bad entry must not poison the list) ──
+
+#[derive(serde::Deserialize)]
+struct Wrapper {
+    #[serde(default, deserialize_with = "backend_auth::deserialize_lenient")]
+    auth: BackendAuth,
+}
+
+#[test]
+fn lenient_absent_is_unsigned() {
+    let w: Wrapper = serde_json::from_str("{}").unwrap();
+    assert_eq!(w.auth, BackendAuth::Unsigned);
+}
+
+#[test]
+fn lenient_null_is_unsigned() {
+    let w: Wrapper = serde_json::from_str(r#"{"auth":null}"#).unwrap();
+    assert_eq!(w.auth, BackendAuth::Unsigned);
+}
+
+#[test]
+fn lenient_valid_role_parses() {
+    let w: Wrapper = serde_json::from_str(
+        r#"{"auth":{"type":"s3_web_identity_role","role_arn":"arn:aws:iam::1:role/r"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        w.auth,
+        BackendAuth::S3WebIdentityRole {
+            role_arn: "arn:aws:iam::1:role/r".into()
+        }
+    );
+}
+
+#[test]
+fn lenient_malformed_becomes_unsupported_not_error() {
+    // Missing role_arn, a wrong-typed value, and an unknown type all degrade to
+    // Unsupported instead of erroring — so they can't fail the whole list parse.
+    for bad in [
+        r#"{"auth":{"type":"s3_web_identity_role"}}"#,
+        r#"{"auth":"garbage"}"#,
+        r#"{"auth":{"type":"gcp_workload_identity","workload_identity_provider":"x"}}"#,
+    ] {
+        let w: Wrapper = serde_json::from_str(bad).unwrap();
+        assert_eq!(w.auth, BackendAuth::Unsupported, "input: {bad}");
+    }
+}
+
 #[test]
 fn unknown_type_deserializes_to_unsupported() {
     // The app-side GCP/Azure variants this proxy build doesn't implement must not

--- a/tests/backend_auth.rs
+++ b/tests/backend_auth.rs
@@ -94,7 +94,7 @@ fn unknown_type_deserializes_to_unsupported() {
 #[test]
 fn unsigned_sets_skip_signature() {
     let mut o = HashMap::new();
-    apply_backend_auth(&BackendAuth::Unsigned, "conn-1", &mut o);
+    apply_backend_auth(&BackendAuth::Unsigned, "conn-1", &mut o).unwrap();
     assert_eq!(o.get("skip_signature").map(String::as_str), Some("true"));
     assert!(!o.contains_key("auth_type"));
 }
@@ -108,7 +108,8 @@ fn web_identity_role_sets_oidc_options_and_keeps_signing() {
         },
         "conn-1",
         &mut o,
-    );
+    )
+    .unwrap();
     assert_eq!(o.get("auth_type").map(String::as_str), Some("oidc"));
     assert_eq!(
         o.get("oidc_role_arn").map(String::as_str),
@@ -123,8 +124,10 @@ fn web_identity_role_sets_oidc_options_and_keeps_signing() {
 }
 
 #[test]
-fn unsupported_serves_unsigned() {
+fn unsupported_fails_closed() {
     let mut o = HashMap::new();
-    apply_backend_auth(&BackendAuth::Unsupported, "conn-1", &mut o);
-    assert_eq!(o.get("skip_signature").map(String::as_str), Some("true"));
+    let result = apply_backend_auth(&BackendAuth::Unsupported, "conn-1", &mut o);
+    assert!(result.is_err());
+    // Must not have set unsigned (or any) options as a side effect.
+    assert!(o.is_empty());
 }

--- a/tests/backend_auth.rs
+++ b/tests/backend_auth.rs
@@ -1,0 +1,82 @@
+//! Native unit tests for the wasm-free `backend_auth` module, included via
+//! `#[path]` (the lib itself is `cdylib` with `test = false`). Mirrors the
+//! pattern in `tests/pagination.rs`.
+
+#[path = "../src/backend_auth.rs"]
+mod backend_auth;
+
+use backend_auth::{apply_backend_auth, BackendAuth};
+use std::collections::HashMap;
+
+// ── deserialization ────────────────────────────────────────────────
+
+#[test]
+fn deserializes_unsigned() {
+    let a: BackendAuth = serde_json::from_str(r#"{"type":"unsigned"}"#).unwrap();
+    assert_eq!(a, BackendAuth::Unsigned);
+}
+
+#[test]
+fn deserializes_web_identity_role() {
+    let a: BackendAuth = serde_json::from_str(
+        r#"{"type":"s3_web_identity_role","role_arn":"arn:aws:iam::1:role/r"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        a,
+        BackendAuth::S3WebIdentityRole {
+            role_arn: "arn:aws:iam::1:role/r".into()
+        }
+    );
+}
+
+#[test]
+fn unknown_type_deserializes_to_unsupported() {
+    // The app-side GCP/Azure variants this proxy build doesn't implement must not
+    // fail deserialization — `#[serde(other)]` catches them.
+    let a: BackendAuth = serde_json::from_str(
+        r#"{"type":"gcp_workload_identity","workload_identity_provider":"x","service_account":"y"}"#,
+    )
+    .unwrap();
+    assert_eq!(a, BackendAuth::Unsupported);
+}
+
+// ── option translation ─────────────────────────────────────────────
+
+#[test]
+fn unsigned_sets_skip_signature() {
+    let mut o = HashMap::new();
+    apply_backend_auth(&BackendAuth::Unsigned, "conn-1", &mut o);
+    assert_eq!(o.get("skip_signature").map(String::as_str), Some("true"));
+    assert!(!o.contains_key("auth_type"));
+}
+
+#[test]
+fn web_identity_role_sets_oidc_options_and_keeps_signing() {
+    let mut o = HashMap::new();
+    apply_backend_auth(
+        &BackendAuth::S3WebIdentityRole {
+            role_arn: "arn:aws:iam::1:role/r".into(),
+        },
+        "conn-1",
+        &mut o,
+    );
+    assert_eq!(o.get("auth_type").map(String::as_str), Some("oidc"));
+    assert_eq!(
+        o.get("oidc_role_arn").map(String::as_str),
+        Some("arn:aws:iam::1:role/r")
+    );
+    assert_eq!(
+        o.get("oidc_subject").map(String::as_str),
+        Some("scv1:conn:conn-1")
+    );
+    // Signing must stay ON for the federated path.
+    assert!(!o.contains_key("skip_signature"));
+}
+
+#[test]
+fn unsupported_serves_unsigned() {
+    let mut o = HashMap::new();
+    apply_backend_auth(&BackendAuth::Unsupported, "conn-1", &mut o);
+    assert_eq!(o.get("skip_signature").map(String::as_str), Some("true"));
+}

--- a/tests/backend_auth.rs
+++ b/tests/backend_auth.rs
@@ -78,17 +78,6 @@ fn lenient_malformed_becomes_unsupported_not_error() {
     }
 }
 
-#[test]
-fn unknown_type_deserializes_to_unsupported() {
-    // The app-side GCP/Azure variants this proxy build doesn't implement must not
-    // fail deserialization — `#[serde(other)]` catches them.
-    let a: BackendAuth = serde_json::from_str(
-        r#"{"type":"gcp_workload_identity","workload_identity_provider":"x","service_account":"y"}"#,
-    )
-    .unwrap();
-    assert_eq!(a, BackendAuth::Unsupported);
-}
-
 // ── option translation ─────────────────────────────────────────────
 
 #[test]

--- a/tests/backend_auth.rs
+++ b/tests/backend_auth.rs
@@ -83,7 +83,7 @@ fn lenient_malformed_becomes_unsupported_not_error() {
 #[test]
 fn unsigned_sets_skip_signature() {
     let mut o = HashMap::new();
-    apply_backend_auth(&BackendAuth::Unsigned, "conn-1", &mut o).unwrap();
+    apply_backend_auth(&BackendAuth::Unsigned, "conn-1", "s3", &mut o).unwrap();
     assert_eq!(o.get("skip_signature").map(String::as_str), Some("true"));
     assert!(!o.contains_key("auth_type"));
 }
@@ -96,6 +96,7 @@ fn web_identity_role_sets_oidc_options_and_keeps_signing() {
             role_arn: "arn:aws:iam::1:role/r".into(),
         },
         "conn-1",
+        "s3",
         &mut o,
     )
     .unwrap();
@@ -115,8 +116,24 @@ fn web_identity_role_sets_oidc_options_and_keeps_signing() {
 #[test]
 fn unsupported_fails_closed() {
     let mut o = HashMap::new();
-    let result = apply_backend_auth(&BackendAuth::Unsupported, "conn-1", &mut o);
+    let result = apply_backend_auth(&BackendAuth::Unsupported, "conn-1", "s3", &mut o);
     assert!(result.is_err());
     // Must not have set unsigned (or any) options as a side effect.
+    assert!(o.is_empty());
+}
+
+#[test]
+fn web_identity_role_on_non_s3_fails_closed() {
+    let mut o = HashMap::new();
+    let result = apply_backend_auth(
+        &BackendAuth::S3WebIdentityRole {
+            role_arn: "arn:aws:iam::1:role/r".into(),
+        },
+        "conn-1",
+        "az",
+        &mut o,
+    );
+    assert!(result.is_err());
+    // No AWS/OIDC options must leak into the non-S3 backend's option map.
     assert!(o.is_empty());
 }

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -51,11 +51,3 @@ def test_federated_object_is_served():
         f"federated read failed ({resp.status_code}): {resp.text[:300]}"
     )
     assert resp.content, "federated read returned an empty body"
-
-
-def test_federated_listing_is_served():
-    """Listing a federated product works (signed ListObjectsV2)."""
-    resp = requests.get(f"{PROXY_URL}/{ACCOUNT}/{PRODUCT}/")
-    assert resp.status_code == 200, (
-        f"federated list failed ({resp.status_code}): {resp.text[:300]}"
-    )

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -13,11 +13,16 @@ the customer-side IAM OIDC provider + role trust policy (conditioned on
 gated on env vars and SKIPS when they are unset. Set them in staging/preview CI
 to activate it (it is discovered automatically by ``pytest tests/``):
 
-  PROXY_URL                base URL of the deployed proxy (shared with the other
-                           integration tests; defaults to http://localhost:8787)
-  FEDERATION_TEST_ACCOUNT  account id of the federated test product
-  FEDERATION_TEST_PRODUCT  product id of the federated test product
-  FEDERATION_TEST_KEY      an object key expected to be readable via federation
+  PROXY_URL                  base URL of the deployed proxy (shared with the other
+                             integration tests; defaults to http://localhost:8787)
+  FEDERATION_TEST_ACCOUNT    account id of the federated test product
+  FEDERATION_TEST_PRODUCT    product id of the public federated test product
+  FEDERATION_TEST_KEY        an object key expected to be readable via federation
+  FEDERATION_RESTRICTED_PRODUCT
+                             product id of a *restricted* federated product in the
+                             same account, used by the authz/confused-deputy test
+                             (an anonymous caller must be denied before federation
+                             reads its private backend)
 """
 
 import os
@@ -29,16 +34,16 @@ PROXY_URL = os.environ.get("PROXY_URL", "http://localhost:8787")
 ACCOUNT = os.environ.get("FEDERATION_TEST_ACCOUNT")
 PRODUCT = os.environ.get("FEDERATION_TEST_PRODUCT")
 KEY = os.environ.get("FEDERATION_TEST_KEY")
+RESTRICTED_PRODUCT = os.environ.get("FEDERATION_RESTRICTED_PRODUCT")
 
-pytestmark = pytest.mark.skipif(
+
+@pytest.mark.skipif(
     not (ACCOUNT and PRODUCT and KEY),
     reason=(
         "federation test target not configured "
         "(set FEDERATION_TEST_ACCOUNT/PRODUCT/KEY against a deployed proxy)"
     ),
 )
-
-
 def test_federated_object_is_served():
     """A private, federated product's object is served via AssumeRoleWithWebIdentity.
 
@@ -47,7 +52,36 @@ def test_federated_object_is_served():
     mismatch, or the API not surfacing the connection's ``role_arn`` to the proxy.
     """
     resp = requests.get(f"{PROXY_URL}/{ACCOUNT}/{PRODUCT}/{KEY}")
+    # A 200 is the success signal; the body may legitimately be empty (a valid
+    # zero-byte S3 object), so don't assert on resp.content.
     assert resp.status_code == 200, (
         f"federated read failed ({resp.status_code}): {resp.text[:300]}"
     )
-    assert resp.content, "federated read returned an empty body"
+
+
+@pytest.mark.skipif(
+    not (ACCOUNT and RESTRICTED_PRODUCT),
+    reason=(
+        "restricted federation target not configured "
+        "(set FEDERATION_TEST_ACCOUNT/FEDERATION_RESTRICTED_PRODUCT)"
+    ),
+)
+def test_restricted_product_denied_to_anonymous():
+    """An unauthorized caller must be denied *before* the proxy federates (#142).
+
+    The confused-deputy guard: a restricted product's subject-scoped Source API
+    lookup returns 403/404 for an anonymous caller, short-circuiting
+    ``resolve_product`` before ``apply_backend_auth`` runs — so the proxy never
+    assumes the role or serves the private backend on an unauthorized caller's
+    behalf. A 200 here would mean federation leaked restricted data.
+
+    The Source API maps unauthorized to AccessDenied (403) or, to avoid leaking
+    existence, NotFound (404); both are acceptable denials. The key invariant is
+    simply: not 200.
+    """
+    key = KEY or "any-key"
+    resp = requests.get(f"{PROXY_URL}/{ACCOUNT}/{RESTRICTED_PRODUCT}/{key}")
+    assert resp.status_code in (401, 403, 404), (
+        "anonymous caller was not denied a restricted federated product "
+        f"(status {resp.status_code}); federation may have served private data"
+    )

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,0 +1,61 @@
+"""Federation smoke test for the Source Cooperative Data Proxy.
+
+Exercises the full federated backend path end-to-end: a request for a product
+backed by an ``s3_web_identity_role`` data connection makes the proxy mint its
+own OIDC assertion, assume the customer role via AWS STS
+``AssumeRoleWithWebIdentity``, and sign the S3 read with the temporary
+credentials.
+
+This needs real infrastructure that can't be stood up in unit tests — a deployed
+proxy, a federated test product whose data connection carries a ``role_arn``, and
+the customer-side IAM OIDC provider + role trust policy (conditioned on
+``aud = sts.amazonaws.com`` and ``sub = scv1:conn:{connection_id}``). So it is
+gated on env vars and SKIPS when they are unset. Set them in staging/preview CI
+to activate it (it is discovered automatically by ``pytest tests/``):
+
+  PROXY_URL                base URL of the deployed proxy (shared with the other
+                           integration tests; defaults to http://localhost:8787)
+  FEDERATION_TEST_ACCOUNT  account id of the federated test product
+  FEDERATION_TEST_PRODUCT  product id of the federated test product
+  FEDERATION_TEST_KEY      an object key expected to be readable via federation
+"""
+
+import os
+
+import pytest
+import requests
+
+PROXY_URL = os.environ.get("PROXY_URL", "http://localhost:8787")
+ACCOUNT = os.environ.get("FEDERATION_TEST_ACCOUNT")
+PRODUCT = os.environ.get("FEDERATION_TEST_PRODUCT")
+KEY = os.environ.get("FEDERATION_TEST_KEY")
+
+pytestmark = pytest.mark.skipif(
+    not (ACCOUNT and PRODUCT and KEY),
+    reason=(
+        "federation test target not configured "
+        "(set FEDERATION_TEST_ACCOUNT/PRODUCT/KEY against a deployed proxy)"
+    ),
+)
+
+
+def test_federated_object_is_served():
+    """A private, federated product's object is served via AssumeRoleWithWebIdentity.
+
+    A 403/500 here means the proxy could not assume the role or sign the request
+    — typically a missing IAM OIDC provider, a trust-policy ``aud``/``sub``
+    mismatch, or the API not surfacing the connection's ``role_arn`` to the proxy.
+    """
+    resp = requests.get(f"{PROXY_URL}/{ACCOUNT}/{PRODUCT}/{KEY}")
+    assert resp.status_code == 200, (
+        f"federated read failed ({resp.status_code}): {resp.text[:300]}"
+    )
+    assert resp.content, "federated read returned an empty body"
+
+
+def test_federated_listing_is_served():
+    """Listing a federated product works (signed ListObjectsV2)."""
+    resp = requests.get(f"{PROXY_URL}/{ACCOUNT}/{PRODUCT}/")
+    assert resp.status_code == 200, (
+        f"federated list failed ({resp.status_code}): {resp.text[:300]}"
+    )


### PR DESCRIPTION
Adapts the proxy's backend connections to make **authenticated** requests, replacing the always-unsigned path. The proxy side is complete end-to-end; production activation is gated on the Source API surfacing the role (see **Production status**).

## Issues

Part of epic #137.

Closes #138 (deserialize `DataConnection.authentication` / `S3WebIdentityRole`), closes #140 (`federate_aws` — assertion + `AssumeRoleWithWebIdentity` + STS XML, delivered by consuming + wiring multistore).

Partially addresses #142 — `resolve_product` wiring is done, but its security-critical authz-ordering **test** (an unauthorized caller never reaches `federate_*`) is currently a doc note, not a test; left open until that's added. Not addressed here: #139 (subject shape — this PR still mints the older `scv1:conn:{id}`; the design pivoted to a fixed product-grained subject), #141 (credential caching — relocated upstream to developmentseed/multistore#56), #143 (per-product session policy).

## Model

`DataConnection` gains an `authentication` field — a sibling of `details`, matching the Source API's shape:

```rust
pub enum BackendAuth {            // #[serde(tag = "type")], default Unsigned
    Unsigned,                                  // public bucket — unsigned requests
    S3WebIdentityRole { role_arn: String },    // federate proxy OIDC identity -> AWS role
    Unsupported,                               // #[serde(other)] — unknown/unimplemented type
}
```

`resolve_product` branches via `apply_backend_auth`, replacing the long-standing `// TODO: provide real backend credentials` forced `skip_signature` insert:

- **Unsigned** (default) → `skip_signature` (current behavior).
- **S3WebIdentityRole** → `auth_type=oidc` + `oidc_role_arn` + a per-connection subject `scv1:conn:{id}`, leaving signing **on** so the middleware injects the federated credentials.
- **Unsupported** → **fails closed** with `BackendAuthError` rather than silently serving unsigned.

## End-to-end federation

`lib.rs` wires `MaybeOidcAuth(AwsBackendAuth(OidcCredentialProvider))` into the gateway via `.with_middleware`, backed by a reqwest `FetchHttpExchange` for the worker. For an `auth_type=oidc` connection the middleware mints the proxy's RS256 assertion (`iss = OIDC_PROVIDER_ISSUER`, `aud = sts.amazonaws.com`, `sub = scv1:conn:{id}`), exchanges it at AWS STS (`AssumeRoleWithWebIdentity`) over fetch, and injects the temporary credentials so the backend request is signed. A no-op for unsigned/public connections.

## Resilience

- **Lenient deserialization** — the proxy parses the whole data-connection list in one `serde_json::from_str`, so a `deserialize_with` degrades a present-but-malformed `authentication` (null, wrong shape, missing `role_arn`, unknown `type`) to `Unsigned`/`Unsupported` instead of failing the entire parse and breaking resolution for *every* product.
- **Fail closed** on `Unsupported` (the app-side `gcp_workload_identity` / `azure_workload_identity` variants this build doesn't implement, or malformed config) — a connection that can't be authenticated isn't served at all, rather than falling back to an anonymously-readable unsigned request.
- **Stale-cache recovery** — the connections list is edge-cached up to 30 min, so a connection created *after* the cache filled would make a referencing product 500 with `data connection '<id>' not found` until the TTL expired. A referenced-but-absent connection now triggers a one-shot cache-bypassing refetch (via a `force_refresh` flag on `get_or_fetch_data_connections`, which also refreshes the shared cache entry) before giving up — so just-added connections, exactly the new private/federated ones this PR enables, resolve immediately instead of waiting out the TTL.

## Performance

The gateway is rebuilt per `fetch()`, so the credential provider is held in an isolate-level `OnceLock` and cloned per request; cloning shares the cache (enabled by the pinned multistore `feat/shareable-credential-cache`), so repeat federated requests reuse cached temporary credentials instead of re-minting a JWT and re-running `AssumeRoleWithWebIdentity` every call.

## Observability

`BackendAuth::kind()` (`unsigned` / `s3_web_identity_role` / `unsupported` — no secrets, no ARN) is recorded on the `resolve_product` span, so an operator can see which backend-auth path a request took and correlate a fail-closed `Unsupported` or an STS 403 without leaking the role ARN.

## Testing

`backend_auth` is extracted into a wasm-free module so it can be natively unit-tested despite the lib being `cdylib` + `test = false` — `tests/backend_auth.rs` includes it via `#[path]`, mirroring `tests/pagination.rs`. Covered: serde round-trips (unknown `type` → `Unsupported`, malformed → degrade, the `s3_web_identity_role` variant) and the option-set translation for each variant, including fail-closed. An env-gated `tests/test_federation.py` smoke test exercises the full live path and **skips** unless `FEDERATION_TEST_ACCOUNT/PRODUCT/KEY` are set.

## Temporary multistore pin

The consolidated backend-auth work (oidc-provider owning the credential exchange, the shareable credential cache) isn't on crates.io yet, so `[patch.crates-io]` pins all five multistore crates to an **exact rev** (not `branch=main`, which `cargo update` could silently float) for reproducible builds. **Drop the patch and bump the versions once multistore ships.**

## Production status

Non-breaking and currently inert: the Source API still redacts `authentication`, so every connection resolves `Unsigned` and behaves exactly as before. Remaining go-live steps (outside this PR):

1. The app surfacing the connection's `role_arn` to the proxy (source.coop #327 / #329).
2. The customer-side IAM OIDC provider + role trust policy (conditioned on `aud = sts.amazonaws.com`, `sub = scv1:conn:{id}`) and a federated test product in staging to activate the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

