### PR TITLE
fix(registry): sync product model with source.coop#284 (drop mirror config, use visibility)

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -233,13 +233,17 @@ async fn resolve_product_inner(
 
 // ── API response types ─────────────────────────────────────────────
 
+/// Product visibility, mirroring `ProductVisibility` in the source.coop data
+/// model. Replaced the legacy `data_mode` field in source.coop#284. Any missing
+/// or unrecognized value deserializes to `Unknown`, which is treated as
+/// non-public so we fail closed.
 #[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum DataMode {
+pub enum Visibility {
+    Public,
+    Unlisted,
+    Restricted,
     #[default]
-    Open,
-    Subscription,
-    Private,
     #[serde(other)]
     Unknown,
 }
@@ -250,13 +254,13 @@ pub struct SourceProduct {
     #[serde(default)]
     pub disabled: bool,
     #[serde(default)]
-    pub data_mode: DataMode,
+    pub visibility: Visibility,
     pub metadata: SourceProductMetadata,
 }
 
 impl SourceProduct {
     pub fn is_public(&self) -> bool {
-        !self.disabled && self.data_mode == DataMode::Open
+        !self.disabled && self.visibility == Visibility::Public
     }
 }
 
@@ -272,15 +276,7 @@ pub struct SourceProductMirror {
     pub storage_type: String,
     pub connection_id: String,
     pub prefix: String,
-    pub config: SourceProductMirrorConfig,
     pub is_primary: bool,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
-pub struct SourceProductMirrorConfig {
-    pub region: Option<String>,
-    pub bucket: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Problem

Creating a product via the [source.coop#338](https://github.com/source-cooperative/source.coop/pull/338) preview branch made the proxy throw on resolve. Root cause is that the proxy's product model drifted from source.coop's after [source.coop#284](https://github.com/source-cooperative/source.coop/pull/284) ("require auth for restricted products"):

1. **Mirror `config` was removed upstream.** `SourceProductMirror.config` had no serde default, so deserializing any product created after #284 failed with `missing field \`config\``. This is the error hit when creating a product on the #338 branch (which lets users pick a data connection and create fresh products).
2. **`data_mode` was replaced by `visibility`.** The proxy still read `data_mode`, which defaulted to `Open`, so `is_public()` silently treated **every** new product as public — which would broadcast even `restricted` products to the public live-map.

## Changes

- **Drop the required `config` field** (and the unused `SourceProductMirrorConfig` struct). It was `#[allow(dead_code)]` and never read — the bucket/region used to build the `BucketConfig` come from the resolved `DataConnection`, not the mirror. Legacy products that still carry `config` keep deserializing fine (the extra field is ignored; we don't `deny_unknown_fields`).
- **Replace `data_mode`/`DataMode` with `visibility`/`Visibility`**, matching the field #284 introduced (`public` / `unlisted` / `restricted`). Missing or unrecognized values deserialize to `Unknown`, which `is_public()` treats as non-public — so we **fail closed** rather than leaking restricted products to the live-map.

`is_public()` only gates the public geolocation broadcast; data-access authz is enforced upstream of federation, so this is not an access-control change.

## Verification

- `cargo check`/`cargo clippy --target wasm32-unknown-unknown` — clean (the lib is wasm-only; `[lib] test = false` by design, so CI covers it via wasm check + clippy).
- `cargo test` (host integration suite) — 25 passed.
- Reproduced out-of-tree against representative new-model JSON: the **old** struct fails with `missing field \`config\``; the **new** struct parses it, yields `is_public()=false` for `restricted` and `true` for `public`, still parses legacy JSON containing `config`, and fails closed when `visibility` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)