### PR TITLE
fix(headers): set Cache-Control: no-transform on all responses

### DIFF
--- a/.github/workflows/please-release.yaml
+++ b/.github/workflows/please-release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+      # Maintenance branches for hotfixes off an older release (e.g. 2.1.x)
+      - "*.x"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -22,4 +25,7 @@ jobs:
       - uses: googleapis/release-please-action@078b9b8dda7799db29972b379561ff8e19b08e82 # v4
         with:
           release-type: rust
+          # Release from whichever branch triggered the run (main or a *.x
+          # maintenance branch), so hotfixes are cut off their own line.
+          target-branch: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}

--- a/src/cache_control.rs
+++ b/src/cache_control.rs
@@ -1,0 +1,27 @@
+//! `Cache-Control` header handling for proxied responses.
+
+/// Computes a `Cache-Control` value that guarantees a `no-transform`
+/// directive is present, preserving any directives already set by the
+/// upstream object (e.g. `max-age`).
+///
+/// Cloudflare otherwise applies transformations that strip the
+/// `Content-Length` header on HTTP/3 HEAD requests:
+/// <https://community.cloudflare.com/t/content-length-header-missing-on-http-3-head-requests/932208>
+///
+/// Returns `None` when `existing` already contains a `no-transform`
+/// directive (case-insensitive), signalling that the header needs no change.
+pub fn ensure_no_transform(existing: &str) -> Option<String> {
+    let already_present = existing
+        .split(',')
+        .any(|directive| directive.trim().eq_ignore_ascii_case("no-transform"));
+    if already_present {
+        return None;
+    }
+
+    let existing = existing.trim();
+    if existing.is_empty() {
+        Some("no-transform".to_string())
+    } else {
+        Some(format!("{existing}, no-transform"))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod analytics;
 mod cache;
+mod cache_control;
 mod handlers;
 mod pagination;
 mod registry;
@@ -136,6 +137,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     }
 
     let response = add_cors(response);
+    let response = add_no_transform(response);
     if !request_id.is_empty() {
         let _ = response.headers().set("x-request-id", &request_id);
     }
@@ -339,6 +341,22 @@ fn add_cors(resp: web_sys::Response) -> web_sys::Response {
     ] {
         if let Err(e) = h.set(name, value) {
             tracing::warn!("failed to set CORS header {}: {:?}", name, e);
+        }
+    }
+    resp
+}
+
+// ── Cache-Control ────────────────────────────────────────────────────
+
+/// Ensure every response carries a `Cache-Control: no-transform` directive so
+/// Cloudflare does not apply transformations that drop the `Content-Length`
+/// header on HTTP/3 HEAD requests. Existing directives are preserved.
+fn add_no_transform(resp: web_sys::Response) -> web_sys::Response {
+    let h = resp.headers();
+    let existing = h.get("cache-control").ok().flatten().unwrap_or_default();
+    if let Some(value) = cache_control::ensure_no_transform(&existing) {
+        if let Err(e) = h.set("cache-control", &value) {
+            tracing::warn!("failed to set cache-control no-transform: {:?}", e);
         }
     }
     resp

--- a/tests/cache_control.rs
+++ b/tests/cache_control.rs
@@ -1,0 +1,46 @@
+#[path = "../src/cache_control.rs"]
+mod cache_control;
+
+use cache_control::ensure_no_transform;
+
+// Regression test for https://community.cloudflare.com/t/content-length-header-missing-on-http-3-head-requests/932208
+// Responses from data.source.coop must carry `Cache-Control: no-transform` so
+// Cloudflare does not strip `Content-Length` on HTTP/3 HEAD requests.
+
+#[test]
+fn adds_directive_when_header_absent() {
+    assert_eq!(ensure_no_transform(""), Some("no-transform".to_string()));
+}
+
+#[test]
+fn adds_directive_when_header_is_whitespace() {
+    assert_eq!(ensure_no_transform("   "), Some("no-transform".to_string()));
+}
+
+#[test]
+fn appends_to_existing_directives() {
+    assert_eq!(
+        ensure_no_transform("max-age=3600"),
+        Some("max-age=3600, no-transform".to_string())
+    );
+}
+
+#[test]
+fn idempotent_when_already_present() {
+    assert_eq!(ensure_no_transform("no-transform"), None);
+    assert_eq!(ensure_no_transform("max-age=60, no-transform"), None);
+}
+
+#[test]
+fn match_is_case_insensitive() {
+    assert_eq!(ensure_no_transform("No-Transform"), None);
+}
+
+#[test]
+fn ignores_substring_false_positive() {
+    // "no-transformation" is not the `no-transform` directive.
+    assert_eq!(
+        ensure_no_transform("no-transformation"),
+        Some("no-transformation, no-transform".to_string())
+    );
+}


### PR DESCRIPTION
## What

Adds a `Cache-Control: no-transform` directive to every response served by the data proxy, preserving any existing `Cache-Control` directives from the upstream S3 object.

## Why

Cloudflare strips the `Content-Length` header on HTTP/3 HEAD requests unless the response opts out of transformations. Setting `no-transform` resolves the missing `Content-Length` reported in:
https://community.cloudflare.com/t/content-length-header-missing-on-http-3-head-requests/932208

## How

- New pure helper `cache_control::ensure_no_transform()` computes the header value (append-if-absent, idempotent, case-insensitive).
- `add_no_transform()` in `lib.rs` applies it to the final response, alongside the existing `add_cors()` step.
- Regression test in `tests/cache_control.rs` covers absent / existing / already-present / case-insensitive / substring-false-positive cases.

## Release path

This is a **hotfix off `v2.1.2`**, targeting the `2.1.x` maintenance branch so it ships as `v2.1.3` **without** bundling the unreleased `fix(registry) #149` sitting on `main`.

This PR also wires release-please to run on `*.x` maintenance branches (`ci(release):` commit). On merge to `2.1.x`, release-please opens a `chore(main): release 2.1.3` PR on that branch.

⚠️ **Forward-port:** after `v2.1.3` is cut, merge `2.1.x` into `main` (or cherry-pick) so the fix isn't lost in the next minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)