### PR TITLE
ci: add Claude PR review workflows from source.coop

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,42 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh issue view:*)"
+            --append-system-prompt "When the request requires code modifications: (1) create a new branch off the default branch named `claude/fix-<short-description>` or `claude/issue-<number>`, (2) make the changes, commit, and push the branch, (3) read `.github/pull_request_template.md`, fill each section (removing the HTML comment instructions), add `Closes #<n>` to 'What I'm changing' if resolving an issue, write the result to a temp file, and run `gh pr create --body-file <path>`, (4) reply in the original thread with the PR link. For read-only questions, skip the PR workflow and just respond."

--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -1,0 +1,101 @@
+name: Claude Auto Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Skip when a PR touches workflow files: the action can't validate/run
+    # against modified workflows and fails with "401 Unauthorized - Workflow
+    # validation failed".
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  review:
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # No track_progress / use_sticky_comment: we deliver a single FORMAL PR
+          # review and supersede the prior one, so there are no accumulating
+          # progress/summary comments across pushes.
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR: ${{ github.event.pull_request.number }}
+
+            You are reviewing this pull request. Deliver exactly ONE formal GitHub
+            pull request review per run, replacing any prior review from earlier runs.
+
+            ABSOLUTE RULE — NO PROBE/TEST WRITES. The ONLY thing you may write to the
+            PR is the single final review in STEP 3 (plus the dismissals in STEP 1).
+            Never post a "test", "test123", placeholder, scratch, or trial comment to
+            verify that the API or line-anchoring works — not as a standalone comment,
+            not as an inline comment, not "just to check". If you are unsure a `gh api`
+            call is correct, reason about it or dry-run the JSON locally with `cat`/`jq`;
+            do NOT probe by posting to the live PR. Any stray comment you leave is
+            visible to the author and is a defect.
+
+            STEP 1 — Supersede prior rounds.
+            List existing reviews:
+              `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --paginate`
+            For each review authored by the Claude app user whose state is APPROVED or
+            CHANGES_REQUESTED (i.e. still active), dismiss it so only this run's review
+            is in effect:
+              `gh api -X PUT repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/<id>/dismissals \
+                 -f message="Superseded by a newer Claude review." -f event=DISMISS`
+
+            STEP 2 — Review the diff (`gh pr diff`) for correctness bugs, security
+            issues, and clear best-practice problems. Skip nits and anything the
+            linter/formatter already enforces. If nothing is blocking, say so briefly —
+            do not pad the review.
+
+            STEP 3 — Submit ONE formal review in a single API call, bundling every
+            inline note in the `comments` array. Build a JSON file and post it:
+              `gh api -X POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input <file>`
+            This POST is the ONLY write you make to the PR in this step, and you make it
+            exactly once. Do not post any comment before it to test the call — build the
+            JSON file, inspect it with `cat`, then post it directly.
+
+            Requirements for that JSON:
+            - "event": "REQUEST_CHANGES" if there are blocking issues, otherwise "COMMENT".
+              Never use "APPROVE" (bot approvals are restricted and not meaningful here).
+            - "body": begin with a single bold verdict line that starts with a clear
+              status emoji — `✅` when nothing is blocking (safe to merge) or `❌` when
+              changes are requested — e.g. `**✅ No blocking issues — safe to merge.**`
+              or `**❌ Changes requested — see findings below.**`. The emoji must match
+              the "event": ✅ pairs with "COMMENT", ❌ pairs with "REQUEST_CHANGES".
+              Follow the verdict line with a brief bullet list. No checklists, no
+              progress logs.
+            - "comments": one entry per finding, each { "path", "line" (and "start_line"
+              for multi-line), "body" }. Anchor each to the exact changed line(s).
+
+            MAKE FINDINGS ONE-CLICK APPLYABLE. Whenever a finding has a concrete code
+            fix, put a GitHub suggestion block in that inline comment's body so the
+            author can apply it with the "Commit suggestion" button:
+
+                ```suggestion
+                <the exact replacement text for the commented line(s)>
+                ```
+
+            The suggestion content must replace the full line range the comment is
+            anchored to (use start_line..line for multi-line replacements). Prefer
+            several small, targeted suggestions over one large comment — they are far
+            easier for the author to apply individually. Reserve plain prose comments
+            for issues that have no mechanical fix.
+
+            Before posting any suggestion block, re-read it and verify it is
+            syntactically complete — balanced brackets, parens, and braces — and that
+            it would compile if committed verbatim. The author applies it with one
+            click, so a malformed suggestion breaks their build. If you are not
+            confident the replacement is exactly correct, describe the fix in prose
+            instead.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
## Summary
- Add `claude.yml` — responds to `@claude` mentions in issues, PR comments, and reviews
- Add `pr-review-comprehensive.yml` ("Claude Auto Review") — automatically posts a single formal review on every non-bot PR, superseding its prior review on each push

Both files are copied verbatim from [source-cooperative/source.coop](https://github.com/source-cooperative/source.coop/tree/main/.github/workflows) and are repo-agnostic (they use `${{ github.repository }}`). They rely on the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)