### PR TITLE
ci: smoke-test the URL wrangler actually published

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,10 @@ jobs:
           for var in ${{ inputs.var_overrides }}; do
             EXTRA_ARGS="$EXTRA_ARGS --var $var"
           done
-          npx wrangler@3 deploy --config ${{ inputs.wrangler_config }} $EXTRA_ARGS
+          # Capture the deploy output so the smoke test can target whatever URL
+          # wrangler actually published, rather than a hardcoded guess.
+          npx wrangler@3 deploy --config ${{ inputs.wrangler_config }} $EXTRA_ARGS \
+            2>&1 | tee deploy.out
 
       - name: Upload worker secrets
         # GitHub environment secrets are the source of truth — anything set
@@ -124,8 +127,25 @@ jobs:
       - name: Get deploy URL
         id: url
         run: |
-          WORKER="${{ inputs.worker_name || 'source-data-proxy' }}"
-          URL="https://${WORKER}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev"
+          # Derive the URL from what wrangler actually published instead of
+          # hardcoding it. wrangler lists the deployed triggers after a
+          # "Deployed <worker> triggers" line, one per line:
+          #   custom routes -> "data.source.coop/* (zone name: ...)"
+          #   workers.dev   -> "https://<worker>.<subdomain>.workers.dev"
+          # Take the first trigger and normalize it to an https base URL. This
+          # works for every environment (preview on workers.dev, staging and
+          # production on custom-domain routes) with no per-env configuration.
+          TRIGGER="$(sed -n '/Deployed .* triggers/,/Current Version ID/p' deploy.out \
+            | grep -oE 'https://[^ ]+|[A-Za-z0-9.-]+\.[A-Za-z]+/\*' \
+            | head -n1)"
+          if [ -z "$TRIGGER" ]; then
+            echo "::error::could not determine deploy URL from wrangler output"
+            cat deploy.out
+            exit 1
+          fi
+          URL="${TRIGGER%/\*}"                       # strip a trailing route glob
+          case "$URL" in https://*) ;; *) URL="https://$URL" ;; esac
+          echo "Resolved deploy URL: $URL"
           echo "deploy_url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Smoke test


### PR DESCRIPTION
## Problem

The reusable deploy workflow's **smoke test** builds its target URL as `https://<worker>.<subdomain>.workers.dev`, but the staging and production workers are served **only via custom-domain routes** (`data.staging.source.coop` / `data.source.coop`) and are not reachable on `workers.dev`. So that URL `404`s and the smoke test fails even though the worker booted fine — which is exactly why the [staging deploy of #132 went red](https://github.com/source-cooperative/data.source.coop/actions/runs/27585278021/job/81554172879) while `data.staging.source.coop` was actually healthy (200). The upcoming production release deploy would fail the same way.

The staging path was doubly wrong: it passes `wrangler_env: staging` (no `worker_name`), so the URL defaulted to the production name `source-data-proxy` instead of `source-data-proxy-staging`.

## Fix

Rather than hardcode a URL per environment, **derive it from what wrangler reports it published**. wrangler lists the deployed triggers after a `Deployed <worker> triggers` line:

```
Deployed source-data-proxy-staging triggers (1.40 sec)
  data.staging.coolnewgeo.com/* (zone name: coolnewgeo.com)
  data.staging.source.coop/* (zone name: coolnewgeo.com)
Current Version ID: ...
```

We capture the deploy output (`| tee deploy.out`), take the first trigger under that line, and normalize it to an https base URL — a custom route (`host/*`) or a workers.dev URL both map cleanly. This stays correct for **preview** (workers.dev), **staging**, and **production** (custom-domain routes) with no per-env config, and follows route changes automatically. If no trigger can be parsed, the step fails loudly with the captured output.

The previous dependency on the `CLOUDFLARE_WORKERS_SUBDOMAIN` repo var is no longer needed for the smoke test.

## Verification

- Parser tested against the real wrangler output for all three shapes:
  - staging `data.staging.{coolnewgeo.com,source.coop}/*` → `https://data.staging.coolnewgeo.com`
  - production `data.source.coop/*` → `https://data.source.coop`
  - preview `https://source-data-proxy-pr-N.source-coop.workers.dev` → unchanged
- Confirmed both staging routes and the smoke-test paths (`/` and `/.well-known/jwks.json`) currently return `200`.
- YAML validates; repo pre-push hooks (fmt, clippy/wasm check, 25 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)