### PR TITLE
refactor: inline single-use is_write_method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,12 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // The proxy is read-only for object/bucket paths, so writes get an
     // S3-style 405 rather than falling through to bucket resolution (which
     // would misleadingly 404). Special endpoints are exempt.
-    if !is_special_path && is_write_method(&parts.method) {
+    if !is_special_path
+        && matches!(
+            parts.method,
+            http::Method::PUT | http::Method::POST | http::Method::DELETE | http::Method::PATCH
+        )
+    {
         let resp = ErrorResponse {
             code: "MethodNotAllowed".to_string(),
             message: "Method Not Allowed".to_string(),
@@ -263,13 +268,6 @@ fn init_tracing(env: &Env) -> tracing::Level {
         .unwrap_or(tracing::Level::WARN);
     tracing::subscriber::set_global_default(WorkerSubscriber::new().with_max_level(max_level)).ok();
     max_level
-}
-
-fn is_write_method(method: &http::Method) -> bool {
-    matches!(
-        *method,
-        http::Method::PUT | http::Method::POST | http::Method::DELETE | http::Method::PATCH
-    )
 }
 
 fn extract_request_id(headers: &http::HeaderMap) -> String {


### PR DESCRIPTION
## What

`is_write_method` was a six-line `matches!` wrapper with exactly one caller. Inline it into the write-method short-circuit and delete the function.

```rust
if !is_special_path
    && matches!(
        parts.method,
        http::Method::PUT | http::Method::POST | http::Method::DELETE | http::Method::PATCH
    )
{
```

## Why

One abstraction, one call site — the helper added a name but no reuse. The inlined `matches!` reads the same and removes the indirection.

## Verification

Full pre-push suite (fmt, clippy wasm32, wasm check, tests) green.

_Found via ponytail over-engineering audit._

🤖 Generated with [Claude Code](https://claude.com/claude-code)