### PR TITLE
refactor: inline single-use parse_bucket_name

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -25,11 +25,6 @@ impl SourceCoopRegistry {
         }
     }
 
-    /// Parse "account:product" bucket name into (account, product).
-    fn parse_bucket_name(name: &str) -> Option<(&str, &str)> {
-        name.split_once(crate::BUCKET_SEPARATOR)
-    }
-
     /// List products for an account via the Source API.
     pub async fn list_products(&self, account: &str) -> Result<Vec<String>, ProxyError> {
         let product_list = crate::cache::get_or_fetch_product_list(
@@ -55,7 +50,9 @@ impl BucketRegistry for SourceCoopRegistry {
         identity: &ResolvedIdentity,
         _operation: &S3Operation,
     ) -> Result<ResolvedBucket, ProxyError> {
-        let (account, product) = Self::parse_bucket_name(name)
+        // Bucket names arrive pre-mapped as "account:product".
+        let (account, product) = name
+            .split_once(crate::BUCKET_SEPARATOR)
             .ok_or_else(|| ProxyError::BucketNotFound(name.to_string()))?;
 
         let subject = match identity {


### PR DESCRIPTION
## What

`parse_bucket_name` was a one-line `split_once` wrapper called from a single place (`get_bucket`). Inline it.

```rust
let (account, product) = name
    .split_once(crate::BUCKET_SEPARATOR)
    .ok_or_else(|| ProxyError::BucketNotFound(name.to_string()))?;
```

## Why

A named helper that wraps a single stdlib call and has one caller is indirection without payoff. The call site is just as clear with `split_once` inline.

## Verification

Full pre-push suite (fmt, clippy wasm32, wasm check, tests) green.

_Found via ponytail over-engineering audit._

🤖 Generated with [Claude Code](https://claude.com/claude-code)