### PR TITLE
refactor: drop unread SourceProductMirror fields

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -256,12 +256,9 @@ pub struct SourceProductMetadata {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct SourceProductMirror {
-    pub storage_type: String,
     pub connection_id: String,
     pub prefix: String,
-    pub is_primary: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## What

`SourceProductMirror` carried `storage_type` and `is_primary` fields that are deserialized from the API but never read anywhere — which is why the struct needed an `#[allow(dead_code)]`. Remove both fields and the attribute.

```rust
#[derive(Debug, Clone, Deserialize)]
pub struct SourceProductMirror {
    pub connection_id: String,
    pub prefix: String,
}
```

## Why

serde ignores unknown JSON fields by default, so a struct only needs the fields it actually uses. Dropping the dead fields also lets the `#[allow(dead_code)]` go, so the lint stays honest for the rest of the struct.

## Verification

`cargo clippy --target wasm32-unknown-unknown` is clean with the allow removed (confirming `connection_id` and `prefix` are both still used). Full pre-push suite green.

_Found via ponytail over-engineering audit._

🤖 Generated with [Claude Code](https://claude.com/claude-code)