### PR TITLE
refactor: percent-encode cache key subject instead of hex

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -112,12 +112,13 @@ pub async fn get_or_fetch_product_list(
 /// cached separately.
 fn cache_key_with_subject(api_url: &str, subject: Option<&str>) -> String {
     match subject {
-        // Hex-encode the subject so the cache key is always a well-formed URL.
-        // Principal names can contain spaces, `&`, `#`, or non-ASCII, any of
-        // which would otherwise corrupt the key or collide distinct subjects.
-        // Hex is injective and URL-safe, so each subject maps to a unique key.
+        // Percent-encode the subject so the cache key is always a well-formed
+        // URL. Principal names can contain spaces, `&`, `#`, or non-ASCII, any
+        // of which would otherwise corrupt the key or collide distinct subjects.
+        // Percent-encoding is injective and URL-safe, so each subject maps to a
+        // unique key.
         Some(subj) => {
-            let encoded: String = subj.bytes().map(|b| format!("{:02x}", b)).collect();
+            let encoded = utf8_percent_encode(subj, PATH_SEGMENT);
             // Pick the query separator defensively. Callers pass query-free
             // URLs today (path segments are percent-encoded above), but a stray
             // `?` must never silently merge into an existing query and forge a


### PR DESCRIPTION
## What

`cache_key_with_subject` hand-rolled hex encoding (`subj.bytes().map(|b| format!("{:02x}", b))`) to make the subject URL-safe in the cache key. The `percent_encoding` crate — already imported in this file, with a `PATH_SEGMENT` set already defined — does the same job.

```rust
let encoded = utf8_percent_encode(subj, PATH_SEGMENT);
```

## Why

Same guarantee (injective, URL-safe), no hand-rolled encoder, and shorter keys (only non-unreserved bytes get expanded, vs. every byte → 2 hex chars). Reuses tooling the file already pulls in rather than reimplementing it.

## Verification

`cargo clippy --target wasm32-unknown-unknown` clean; full pre-push suite green. `utf8_percent_encode` returns a `Display` type so the `format!` key construction is unchanged.

_Found via ponytail over-engineering audit._

🤖 Generated with [Claude Code](https://claude.com/claude-code)