### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Bumps `quinn-proto` 0.11.14 → 0.11.15 to resolve [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) — a high-severity (7.5) remote memory exhaustion via unbounded out-of-order stream reassembly. `quinn-proto` is a transitive dependency; lockfile-only change.

`cargo audit` is clean locally (exit 0).

Splitting this out of #147 so the security fix can land on `main` independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)