### PR TITLE
feat: accept multiple audiences for /.sts token exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,8 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ae47947aa57e1cfefcbe1eba035abd0033154c56e95812e9a34cf4c43aad06"
+source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,8 +935,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518e3a40526f673ed6b0e032c9cec7f45c917a7a50fdf7fca375f27b16e0f253"
+source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -961,8 +959,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b3ee44b4a1f68ce7b97f288cf1f105f6e5d2f073c2bb06617b9380c29235d4"
+source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
 dependencies = [
  "base64",
  "chrono",
@@ -981,8 +978,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc11cdbe2bb11e105db4ceb63cdcf0ed89155df0f2da6248bcd532666d3db27"
+source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -992,8 +988,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97639b653d38ac5a5bdc01fe400275df028a481188634bee21991a211e19b9e6"
+source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,8 +908,8 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.5.1"
-source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
+version = "0.6.0"
+source = "git+https://github.com/developmentseed/multistore?tag=v0.6.0#b0f5b7fed72d216d3474ebffacc6de1c074e616f"
 dependencies = [
  "async-trait",
  "base64",
@@ -920,6 +920,7 @@ dependencies = [
  "hmac",
  "http",
  "matchit 0.8.6",
+ "md-5",
  "object_store",
  "percent-encoding",
  "quick-xml 0.37.5",
@@ -934,8 +935,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.5.1"
-source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
+version = "0.6.0"
+source = "git+https://github.com/developmentseed/multistore?tag=v0.6.0#b0f5b7fed72d216d3474ebffacc6de1c074e616f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -958,8 +959,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.5.1"
-source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
+version = "0.6.0"
+source = "git+https://github.com/developmentseed/multistore?tag=v0.6.0#b0f5b7fed72d216d3474ebffacc6de1c074e616f"
 dependencies = [
  "base64",
  "chrono",
@@ -977,8 +978,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.5.1"
-source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
+version = "0.6.0"
+source = "git+https://github.com/developmentseed/multistore?tag=v0.6.0#b0f5b7fed72d216d3474ebffacc6de1c074e616f"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -987,8 +988,8 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.5.1"
-source = "git+https://github.com/developmentseed/multistore?branch=feat%2Fmulti-audience#bccb584e3504954770298609eb35b4839bb08b9a"
+version = "0.6.0"
+source = "git+https://github.com/developmentseed/multistore?tag=v0.6.0#b0f5b7fed72d216d3474ebffacc6de1c074e616f"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,13 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
+
+# TEMPORARY: build against the multi-audience branch of multistore until it is
+# released. Remove this block and bump the multistore* versions above once
+# https://github.com/developmentseed/multistore/pull/90 ships a release.
+[patch.crates-io]
+multistore = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ path = "tests/backend_auth.rs"
 
 [dependencies]
 # Multistore
-multistore = { version = "0.5.1", features = ["azure"] }
-multistore-oidc-provider = { version = "0.5.1" }
-multistore-path-mapping = { version = "0.5.1" }
-multistore-sts = { version = "0.5.1" }
+multistore = { version = "0.6.0", features = ["azure"] }
+multistore-oidc-provider = { version = "0.6.0" }
+multistore-path-mapping = { version = "0.6.0" }
+multistore-sts = { version = "0.6.0" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -45,7 +45,7 @@ tracing = "0.1"
 # Pulled in transitively via object_store -> rand. getrandom doesn't support
 # wasm32-unknown-unknown unless the `wasm_js` backend is enabled, so opt in here.
 getrandom = { version = "0.4", features = ["wasm_js"] }
-multistore-cf-workers = { version = "0.5.1", features = ["azure"] }
+multistore-cf-workers = { version = "0.6.0", features = ["azure"] }
 # On wasm32-unknown-unknown reqwest selects its browser `fetch` backend by
 # target arch (not a cargo feature), so the default TLS/backend features are
 # unnecessary here. We only use `Client::new()`, `.send()` and `.text()`, none
@@ -65,12 +65,14 @@ web-sys = { version = "0.3", features = [
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
 
-# TEMPORARY: build against the multi-audience branch of multistore until it is
-# released. Remove this block and bump the multistore* versions above once
-# https://github.com/developmentseed/multistore/pull/90 ships a release.
+# multistore-cf-workers 0.6.0 is not on crates.io, so all multistore crates are
+# pinned to the v0.6.0 git tag to keep `multistore` single-sourced: a git
+# cf-workers alongside registry crates would pull two copies of `multistore`
+# and fail to compile. Remove this block once multistore-cf-workers 0.6.0
+# publishes and the version deps above resolve from crates.io.
 [patch.crates-io]
-multistore = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "feat/multi-audience" }
+multistore = { git = "https://github.com/developmentseed/multistore", tag = "v0.6.0" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", tag = "v0.6.0" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", tag = "v0.6.0" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", tag = "v0.6.0" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", tag = "v0.6.0" }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Set in `wrangler.toml` or via the Cloudflare dashboard:
 | `SOURCE_API_URL`             | `https://source.coop`       | Source Cooperative API base URL                                                                                                    |
 | `LOG_LEVEL`                  | `WARN`                      | Tracing level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`)                                                                          |
 | `AUTH_ISSUER`                | `https://auth.source.coop`  | OIDC issuer trusted for `/.sts` token exchange                                                                                     |
-| `AUTH_AUDIENCE`              | —                           | OAuth client ID that `/.sts` subject tokens must be issued to (`aud` claim). Unset = `/.sts` token exchange is disabled (returns 501) |
+| `AUTH_AUDIENCE`              | —                           | Comma-separated OAuth client ID(s) that `/.sts` subject tokens must be issued to (`aud` claim); a token is accepted if it matches any. Unset = `/.sts` token exchange is disabled (returns 501) |
 | `OIDC_PROVIDER_ISSUER`       | `https://data.source.coop`  | Issuer URL for minted JWTs and OIDC discovery                                                                                      |
 | `OIDC_PROVIDER_KID`          | `data-proxy-1`              | Key ID for the active signing key                                                                                                  |
 | `OIDC_PROVIDER_KID_PREVIOUS` | —                           | Key ID for the previous key (during rotation)                                                                                      |

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,12 +79,19 @@ fn build_config(env: &Env) -> AppConfig {
         .map(|v| v.to_string())
         .expect("AUTH_ISSUER must be set");
 
-    let auth_audience = env
+    // AUTH_AUDIENCE is a comma-separated list of OAuth client IDs whose tokens
+    // `/.sts` accepts (e.g. the web app and the CLI). A token is accepted if its
+    // `aud` matches any entry.
+    let auth_audiences: Vec<String> = env
         .var("AUTH_AUDIENCE")
         .map(|v| v.to_string())
         .ok()
-        .filter(|s| !s.is_empty());
-    if auth_audience.is_none() {
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if auth_audiences.is_empty() {
         // Fail closed: without an audience restriction, an ID token minted for
         // ANY OAuth client of AUTH_ISSUER could be exchanged for a user's
         // credentials, so /.sts is disabled entirely (returns 501) until set.
@@ -96,7 +103,7 @@ fn build_config(env: &Env) -> AppConfig {
         oidc,
         session_token_key,
         auth_issuer,
-        auth_audience,
+        auth_audiences,
     }
 }
 
@@ -107,10 +114,11 @@ pub struct AppConfig {
     pub session_token_key: TokenKey,
     /// OIDC issuer URL for the Source Cooperative auth provider (e.g. `https://auth.source.coop`).
     pub auth_issuer: String,
-    /// OAuth client ID that subject tokens presented to `/.sts` must be
-    /// issued to (the `aud` claim). Required; `None` disables the `/.sts`
-    /// endpoint entirely (returns 501) rather than accepting any audience.
-    pub auth_audience: Option<String>,
+    /// OAuth client IDs that subject tokens presented to `/.sts` may be issued
+    /// to (the `aud` claim); a token is accepted if it matches any. Parsed from
+    /// the comma-separated `AUTH_AUDIENCE`. Empty disables `/.sts` entirely
+    /// (returns 501) rather than accepting any audience.
+    pub auth_audiences: Vec<String>,
 }
 
 pub struct OidcConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // without it, an ID token minted for any OAuth client of AUTH_ISSUER could
     // be exchanged for a user's credentials. When unset, refuse the endpoint
     // with a 501 rather than serving it unrestricted.
-    if parts.path == "/.sts" && config.auth_audience.is_none() {
+    if parts.path == "/.sts" && config.auth_audiences.is_empty() {
         let resp = ErrorResponse {
             code: "NotImplemented".to_string(),
             message: "STS token exchange is not configured".to_string(),
@@ -208,9 +208,9 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // Mount STS token exchange only when an audience restriction is configured.
     // The unset case is refused by the fail-closed 501 short-circuit above, so
     // an unrestricted exchanger is never registered.
-    if let Some(audience) = &config.auth_audience {
+    if !config.auth_audiences.is_empty() {
         let sts_registry =
-            StsCredentialRegistry::new(config.auth_issuer.clone(), Some(audience.clone()));
+            StsCredentialRegistry::new(config.auth_issuer.clone(), config.auth_audiences.clone());
         router = router.with_sts(
             "/.sts",
             sts_registry,

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -20,17 +20,18 @@ pub struct StsCredentialRegistry {
 impl StsCredentialRegistry {
     /// Create a new registry whose `_default` role trusts the given auth issuer.
     ///
-    /// `required_audience` restricts token exchange to subject tokens minted
-    /// for a specific OAuth client (the `aud` claim). Without it, an ID token
-    /// a user granted to any third-party client registered with the issuer
-    /// could be exchanged for that user's proxy credentials.
-    pub fn new(oidc_issuer: String, required_audience: Option<String>) -> Self {
+    /// `required_audiences` restricts token exchange to subject tokens minted
+    /// for one of these OAuth clients (the `aud` claim); a token is accepted if
+    /// it matches any. An empty list would let an ID token a user granted to any
+    /// third-party client registered with the issuer be exchanged for that
+    /// user's proxy credentials, so callers gate on a non-empty list.
+    pub fn new(oidc_issuer: String, required_audiences: Vec<String>) -> Self {
         Self {
             default_role: RoleConfig {
                 role_id: "_default".to_string(),
                 name: "Default".to_string(),
                 trusted_oidc_issuers: vec![oidc_issuer],
-                required_audience,
+                required_audiences,
                 subject_conditions: vec![],
                 allowed_scopes: vec![], // unlimited
                 max_session_duration_secs: 3600,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,9 +31,9 @@ SOURCE_API_URL = "https://source.coop"
 #   OIDC_PROVIDER_KID_PREVIOUS - Key ID for previous key
 # Recommended vars:
 # Required vars (to enable /.sts token exchange):
-#   AUTH_AUDIENCE - OAuth client_id that /.sts subject tokens must be issued to
-#                   (the `aud` claim). Unset = /.sts is disabled (returns 501);
-#                   set to your OAuth client_id to enable it.
+#   AUTH_AUDIENCE - comma-separated OAuth client_id(s) that /.sts subject tokens
+#                   must be issued to (the `aud` claim). A token is accepted if
+#                   it matches any. Unset = /.sts is disabled (returns 501).
 # TODO: Set different sampling rates for prod vs staging
 [observability]
 enabled = true
@@ -68,7 +68,7 @@ routes = [
 
 [env.staging.vars]
 LOG_LEVEL = "DEBUG"
-AUTH_AUDIENCE = "1123dfa8-469f-44fe-b9f4-9b76f06fd325"  # Ory OAuth client_id for staging
+AUTH_AUDIENCE = "1123dfa8-469f-44fe-b9f4-9b76f06fd325,a79c9537-be78-454a-9ea1-b96a1be811cc"  # staging Ory client_ids: frontend + source-coop-cli
 AUTH_ISSUER = "https://auth.staging.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.staging.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"


### PR DESCRIPTION
## What

`/.sts` previously trusted a **single** OAuth client (`AUTH_AUDIENCE`), which is the web frontend. The `source-coop-cli` CLI authenticates as its **own** client, so its token's `aud` was rejected (`InvalidIdentityToken: audience mismatch`). This makes `AUTH_AUDIENCE` a **comma-separated list** — a token is accepted if its `aud` matches **any** entry.

## Changes
- `src/config.rs` — split `AUTH_AUDIENCE` on `,` → `auth_audiences: Vec<String>` (trim/drop empties). Empty list still fail-closes `/.sts` to 501.
- `src/lib.rs`, `src/sts.rs` — pass the list through to `RoleConfig.required_audiences`.
- `wrangler.toml` — staging `AUTH_AUDIENCE` now includes the CLI client: `…frontend…,a79c9537…` (source-coop-cli).
- `README.md` — documents the comma-separated format.

## Dependency
Requires multi-audience support in the crate: **developmentseed/multistore#90** (`RoleConfig.required_audience` → `required_audiences`). Until that releases, this is pinned via a **temporary `[patch.crates-io]` git override** (clearly marked in `Cargo.toml`). **Before merge:** release multistore, bump `multistore*` to that version, and remove the patch block.

## Verify
- `cargo check --lib --target wasm32-unknown-unknown` — clean
- `cargo test` (routing/pagination/backend_auth) — 35 pass

## Follow-up
- **Prod**: `AUTH_AUDIENCE` for production isn't in `wrangler.toml` (set via Cloudflare). It needs the prod CLI client `197e20e7-d52d-4d1d-9e54-4b73a342034b` added alongside the prod frontend client there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)