### PR TITLE
feat: make STS max session TTL configurable via env var

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -98,14 +98,29 @@ fn build_config(env: &Env) -> AppConfig {
         tracing::warn!("AUTH_AUDIENCE not set: /.sts token exchange is disabled (returns 501)");
     }
 
-    // Ceiling for client-requested DurationSeconds on /.sts. Clamped against
-    // multistore's 900s floor. Unset → 3600 (1h), matching multistore's own
-    // default so behavior is unchanged until explicitly raised.
-    let sts_max_session_duration_secs = env
-        .var("STS_MAX_SESSION_DURATION_SECS")
-        .ok()
-        .and_then(|v| v.to_string().parse::<u64>().ok())
-        .unwrap_or(3600);
+    // Ceiling for client-requested DurationSeconds on /.sts. Unset → 3600 (1h),
+    // matching multistore's own default so behavior is unchanged until raised.
+    let sts_max_session_duration_secs = match env.var("STS_MAX_SESSION_DURATION_SECS") {
+        Err(_) => 3600, // unset
+        Ok(v) => match v.to_string().parse::<u64>() {
+            Err(_) => {
+                tracing::warn!(
+                    "STS_MAX_SESSION_DURATION_SECS is not a valid integer; falling back to 3600"
+                );
+                3600
+            }
+            // multistore clamps the requested duration to `(900, this)`, which
+            // panics if `this` < 900, so floor it at multistore's 900s minimum.
+            Ok(n) if n < 900 => {
+                tracing::warn!(
+                    value = n,
+                    "STS_MAX_SESSION_DURATION_SECS is below the 900s floor; using 900"
+                );
+                900
+            }
+            Ok(n) => n,
+        },
+    };
 
     AppConfig {
         api_base_url,

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,12 +98,22 @@ fn build_config(env: &Env) -> AppConfig {
         tracing::warn!("AUTH_AUDIENCE not set: /.sts token exchange is disabled (returns 501)");
     }
 
+    // Ceiling for client-requested DurationSeconds on /.sts. Clamped against
+    // multistore's 900s floor. Unset → 3600 (1h), matching multistore's own
+    // default so behavior is unchanged until explicitly raised.
+    let sts_max_session_duration_secs = env
+        .var("STS_MAX_SESSION_DURATION_SECS")
+        .ok()
+        .and_then(|v| v.to_string().parse::<u64>().ok())
+        .unwrap_or(3600);
+
     AppConfig {
         api_base_url,
         oidc,
         session_token_key,
         auth_issuer,
         auth_audiences,
+        sts_max_session_duration_secs,
     }
 }
 
@@ -119,6 +129,9 @@ pub struct AppConfig {
     /// the comma-separated `AUTH_AUDIENCE`. Empty disables `/.sts` entirely
     /// (returns 501) rather than accepting any audience.
     pub auth_audiences: Vec<String>,
+    /// Ceiling for client-requested STS session length (`DurationSeconds`),
+    /// in seconds. From `STS_MAX_SESSION_DURATION_SECS`; defaults to 3600 (1h).
+    pub sts_max_session_duration_secs: u64,
 }
 
 pub struct OidcConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,11 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     // The unset case is refused by the fail-closed 501 short-circuit above, so
     // an unrestricted exchanger is never registered.
     if !config.auth_audiences.is_empty() {
-        let sts_registry =
-            StsCredentialRegistry::new(config.auth_issuer.clone(), config.auth_audiences.clone());
+        let sts_registry = StsCredentialRegistry::new(
+            config.auth_issuer.clone(),
+            config.auth_audiences.clone(),
+            config.sts_max_session_duration_secs,
+        );
         router = router.with_sts(
             "/.sts",
             sts_registry,

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -25,7 +25,16 @@ impl StsCredentialRegistry {
     /// it matches any. An empty list would let an ID token a user granted to any
     /// third-party client registered with the issuer be exchanged for that
     /// user's proxy credentials, so callers gate on a non-empty list.
-    pub fn new(oidc_issuer: String, required_audiences: Vec<String>) -> Self {
+    ///
+    /// `max_session_duration_secs` is the ceiling for client-requested
+    /// `DurationSeconds`. Clients still get the multistore default (1h) unless
+    /// they request more, up to this cap. These are self-minted sealed-token
+    /// credentials with no revocation, so a longer TTL widens the leak window.
+    pub fn new(
+        oidc_issuer: String,
+        required_audiences: Vec<String>,
+        max_session_duration_secs: u64,
+    ) -> Self {
         Self {
             default_role: RoleConfig {
                 role_id: "_default".to_string(),
@@ -34,7 +43,7 @@ impl StsCredentialRegistry {
                 required_audiences,
                 subject_conditions: vec![],
                 allowed_scopes: vec![], // unlimited
-                max_session_duration_secs: 3600,
+                max_session_duration_secs,
             },
         }
     }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,10 @@ AUTH_ISSUER = "https://auth.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
 SOURCE_API_URL = "https://source.coop"
+# Ceiling for client-requested /.sts DurationSeconds (seconds). 43200 = 12h,
+# 86400 = 24h. Unset → 3600 (1h). Clients must request DurationSeconds to use
+# more than 1h; this only raises the cap.
+STS_MAX_SESSION_DURATION_SECS = "43200"
 
 # Required secrets (managed as GitHub environment secrets; CI re-uploads them
 # via `wrangler secret bulk` on every deploy — see .github/workflows/deploy.yml):
@@ -73,6 +77,7 @@ AUTH_ISSUER = "https://auth.staging.source.coop"
 OIDC_PROVIDER_ISSUER = "https://data.staging.source.coop"
 OIDC_PROVIDER_KID = "data-proxy-1"
 SOURCE_API_URL = "https://staging.source.coop"
+STS_MAX_SESSION_DURATION_SECS = "43200"  # 12h ceiling for client-requested /.sts DurationSeconds
 
 [[env.staging.analytics_engine_datasets]]
 binding = "ANALYTICS"


### PR DESCRIPTION
## What I'm changing

Makes the `/.sts` token-exchange **max session duration** configurable via a new `STS_MAX_SESSION_DURATION_SECS` env var, instead of being hardcoded to 1h. Set to **12h (43200)** in production and staging.

## How I did it

- `src/config.rs` — parse `STS_MAX_SESSION_DURATION_SECS`; **unset → 3600 (1h)**, matching multistore's own default, so behavior is unchanged until the var is set.
- `src/sts.rs` — `StsCredentialRegistry::new` now takes the ceiling as a parameter rather than hardcoding `3600`.
- `src/lib.rs` — passes `config.sts_max_session_duration_secs` into the registry.
- `wrangler.toml` — `STS_MAX_SESSION_DURATION_SECS = "43200"` in both `[vars]` and `[env.staging.vars]` (Workers envs don't inherit top-level vars). Use `86400` for 24h.

**Note on the per-request default:** the value a client gets when it *omits* `DurationSeconds` is hardcoded to 1h *inside the multistore crate* (`unwrap_or(3600)`), with no `RoleConfig`/`with_sts` hook to override it. This PR only raises the **ceiling**. Clients opt into a longer TTL by passing `DurationSeconds` up to the cap:

- aws CLI: `aws sts assume-role-with-web-identity --duration-seconds 43200 …`
- boto3: `assume_role_with_web_identity(..., DurationSeconds=43200)`
- web app / `source-coop-cli`: include `DurationSeconds=43200` in the `/.sts` POST body

Raising the default server-side would need an upstream multistore change; deferred since these clients are under our control.

**Security note:** `/.sts` credentials are self-minted sealed tokens with **no revocation** (only key rotation invalidates them, all at once), so a longer ceiling widens the leak window on a compromised token. Hence env-gated at 12h rather than 24h.

## How to test it

1. With `STS_MAX_SESSION_DURATION_SECS=43200`, exchange a token at `/.sts` requesting `DurationSeconds=43200` → credential `Expiration` ~12h out.
2. Request `DurationSeconds=86400` (above cap) → clamped to 43200.
3. Omit `DurationSeconds` → 1h (multistore default, unchanged).
4. Unset the var → ceiling falls back to 1h.

## PR Checklist

- [x] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR. <!-- config plumbing only; the TTL clamp logic lives in multistore and is covered there -->
- [x] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop) only insofar as clients must pass `DurationSeconds` to use >1h; no API change required.

## Related Issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
