### PR TITLE
fix(deps): bump multistore to the non-S3 streaming-upload guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71e51edda762322d20f852f42b4a338f53264750"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71e51edda762322d20f852f42b4a338f53264750"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71e51edda762322d20f852f42b4a338f53264750"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71e51edda762322d20f852f42b4a338f53264750"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71e51edda762322d20f852f42b4a338f53264750"
 dependencies = [
  "aes-gcm",
  "base64",


### PR DESCRIPTION
## What

Bump the `multistore` git-branch pin in `Cargo.lock` from `71b1513a` → `71e51edd`.

`main` builds against the `fix/decode-aws-chunked-writes` branch of multistore via the temporary `[patch.crates-io]` block (added in #162). That branch got a follow-up fix from a 4-agent review, and this bumps the lock to pick it up.

## Why

The pinned commit (`71b1513a`) had a bug: a **default aws-cli/SDK aws-chunked `PutObject` to a non-S3 backend** (azure — which is enabled here) reached the S3-only seed-signing path (`build_streaming_forward`) with no backend-type guard, so it mis-routed into S3 SigV4 signing instead of being rejected. `UploadPart` already guarded this earlier; `PutObject` did not.

`71e51edd` ([multistore#92](https://github.com/developmentseed/multistore/pull/92)):
- guards the streaming path on `is_s3_backend()` and rejects non-S3 streaming uploads with `InvalidRequest`;
- removes a dead/unreachable `Internal` re-read of `x-amz-content-sha256`;
- adds a non-S3 rejection regression test and strengthens the `UploadPart` test.

## Verification

Pre-commit hook built the wasm worker against `71e51edd` and ran the full data.source.coop suite (green). multistore-side: `clippy -D warnings` clean, 111 tests, wasm `cf-workers` compiles.

## Note

This is a lock bump against the temporary git-branch patch. Once multistore #92 ships in a release, the `[patch.crates-io]` block should be dropped and the `multistore*` deps bumped to the released version (see the TODO in `Cargo.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
