### PR TITLE
chore(deps): bump multistore to fix/decode-aws-chunked-writes @ 35f5aad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#35f5aad639e93707241c364febb9fd0c81406528"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#35f5aad639e93707241c364febb9fd0c81406528"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#35f5aad639e93707241c364febb9fd0c81406528"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#35f5aad639e93707241c364febb9fd0c81406528"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.0"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#71b1513a7eacb866328a72eb85818603e859424c"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fdecode-aws-chunked-writes#35f5aad639e93707241c364febb9fd0c81406528"
 dependencies = [
  "aes-gcm",
  "base64",


### PR DESCRIPTION
Refreshes the git-pinned `multistore*` crates from `71b1513` → `35f5aad` (the current HEAD of `fix/decode-aws-chunked-writes`), which now includes the merged [developmentseed/multistore#93](https://github.com/developmentseed/multistore/pull/93) — *forward flexible-checksum headers on multipart ops*.

## Why

Modern AWS CLI/SDK enable CRC32 integrity checksums by default. The proxy's raw-signed multipart path dropped the client's `x-amz-checksum-*` headers on Create/Complete, so large multipart uploads via `aws s3 cp` failed with:

```
InvalidPart ... CompleteMultipartUpload ... One or more of the specified parts could not be found.
```

#93 forwards (and signs) those headers, fixing it. This bump pulls that fix into the proxy.

## Scope

Lockfile-only — `Cargo.toml` already tracks the `fix/decode-aws-chunked-writes` branch; only `Cargo.lock` moves to the new commit.

## Verification

- `cargo check --target wasm32-unknown-unknown` ✅
- `cargo test` ✅ (routing / pagination / authz / backend_auth — all green)
- pre-push hook (fmt + clippy-wasm + check-wasm + test) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)