### PR TITLE
chore(deps): track multistore main for the HEAD cache-bypass fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,8 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e6e4ce2238a7315cba3934bb362a435df7a6031c407f234b58c64585fe4c28"
+source = "git+https://github.com/developmentseed/multistore?branch=main#973bff70b2ffb59fc7bf825a267359e660b66ad1"
 dependencies = [
  "async-trait",
  "base64",
@@ -937,8 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b938b67468660c53f631e40e52f090bd59732c905c0155beda02f9dc6d64d52a"
+source = "git+https://github.com/developmentseed/multistore?branch=main#973bff70b2ffb59fc7bf825a267359e660b66ad1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -962,8 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41553a965899da911d5a6b6c3be01810db8934667660a1b4ec488c307d5f361f"
+source = "git+https://github.com/developmentseed/multistore?branch=main#973bff70b2ffb59fc7bf825a267359e660b66ad1"
 dependencies = [
  "base64",
  "chrono",
@@ -982,8 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7a0dcfae3cebdc2a20f5be4c8d2d5633aa87ed45df6d418c2ce549d4a73eac"
+source = "git+https://github.com/developmentseed/multistore?branch=main#973bff70b2ffb59fc7bf825a267359e660b66ad1"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -993,8 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35872fed83157576bd67a1abdc854345e19e0d96bb74f5457660839edefd502e"
+source = "git+https://github.com/developmentseed/multistore?branch=main#973bff70b2ffb59fc7bf825a267359e660b66ad1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,16 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
+
+# Build against multistore `main` to pick up fixes that haven't shipped in a
+# crates.io release yet (currently the Cloudflare HEAD subrequest cache-bypass
+# fix: https://github.com/developmentseed/multistore/pull/95). Cargo.lock pins
+# the exact commit, so builds stay reproducible; run `cargo update -p multistore`
+# to advance. Drop this block and bump the multistore* versions above once a
+# release includes the needed fix.
+[patch.crates-io]
+multistore = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "main" }


### PR DESCRIPTION
## What

Adds a `[patch.crates-io]` block pinning the `multistore*` crates to upstream `main` (commit `973bff7`), so the data proxy builds with fixes not yet in a crates.io release.

## Why

multistore `main` now contains the **Cloudflare HEAD subrequest cache-bypass fix** (developmentseed/multistore#95). Without it, Cloudflare rewrites the Worker's outbound `HEAD` into a `GET` for keys with cacheable static-asset extensions (`.dmg`, `.tif`, `.zip`, `.gif`, …); because each backend read is a presigned URL signed for the *original* method, the rewritten `GET` fails SigV4 and S3 returns `403 SignatureDoesNotMatch`.

Symptom: `HEAD` on `*.dmg` returned 403 (and the app rendered such files as empty directories), while `HEAD` on extension-less keys and all `GET`s worked. `main` also already includes the aws-chunked streaming-resign fix (#92, shipped in 0.6.1).

## Notes

- `Cargo.lock` pins the exact commit, so builds stay reproducible; `cargo update -p multistore` advances it.
- Drop this `[patch.crates-io]` block and bump the `multistore*` versions once a crates.io release includes #95.
- Verified locally: `cargo check --target wasm32-unknown-unknown` builds against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
