### PR TITLE
feat(worker): aggregate live-globe activity by datacenter

### DIFF
--- a/workers/public-log-stream/src/aggregate.mjs
+++ b/workers/public-log-stream/src/aggregate.mjs
@@ -1,0 +1,27 @@
+// Pure, runtime-free shaping helpers — kept as plain JS so `node --test` can
+// exercise them without a TS build step or extra deps. Imported by the DO.
+
+/**
+ * Top-k products by request count, count descending.
+ * @param {Map<string, number>} products
+ * @param {number} k
+ * @returns {[string, number][]}
+ */
+export function topProducts(products, k) {
+  return [...products.entries()].sort((a, b) => b[1] - a[1]).slice(0, k);
+}
+
+/**
+ * Shape the per-colo accumulator into the wire payload: one entry per
+ * datacenter with its request count and top products this window.
+ * @param {Map<string, {n: number, products: Map<string, number>}>} colos
+ * @param {number} maxProducts
+ * @returns {{colo: string, n: number, p: [string, number][]}[]}
+ */
+export function buildLocs(colos, maxProducts) {
+  return [...colos.entries()].map(([colo, e]) => ({
+    colo,
+    n: e.n,
+    p: topProducts(e.products, maxProducts),
+  }));
+}

--- a/workers/public-log-stream/src/aggregate.test.mjs
+++ b/workers/public-log-stream/src/aggregate.test.mjs
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { topProducts, buildLocs } from "./aggregate.mjs";
+
+test("topProducts: highest counts first, capped at k", () => {
+  const m = new Map([
+    ["a/x", 3],
+    ["a/y", 10],
+    ["a/z", 1],
+    ["a/w", 7],
+  ]);
+  assert.deepEqual(topProducts(m, 2), [
+    ["a/y", 10],
+    ["a/w", 7],
+  ]);
+});
+
+test("topProducts: returns all when fewer than k", () => {
+  assert.deepEqual(topProducts(new Map([["a/x", 2]]), 5), [["a/x", 2]]);
+});
+
+test("buildLocs: one entry per colo with top products", () => {
+  const colos = new Map([
+    [
+      "EWR",
+      { n: 5, products: new Map([["nasa/landsat", 4], ["esa/s2", 1]]) },
+    ],
+  ]);
+  assert.deepEqual(buildLocs(colos, 5), [
+    { colo: "EWR", n: 5, p: [["nasa/landsat", 4], ["esa/s2", 1]] },
+  ]);
+});

--- a/workers/public-log-stream/src/location-hub.ts
+++ b/workers/public-log-stream/src/location-hub.ts
@@ -1,47 +1,40 @@
 import { DurableObject } from "cloudflare:workers";
+import { buildLocs } from "./aggregate.mjs";
 
 export interface Env {
   LOCATION_HUB: DurableObjectNamespace<LocationHub>;
   EMIT_INTERVAL_MS: string;
-  MAX_BROADCASTS_PER_EMIT: string;
+  MAX_PRODUCTS_PER_COLO: string;
   CORS_ORIGIN: string;
 }
 
+// Posted by the proxy per successful public-product GET. Only the datacenter
+// (colo) and the product are used; requester geolocation is intentionally
+// never forwarded to viewers.
 export interface LocationEvent {
-  lat: number;
-  lon: number;
-  city?: string;
-  country?: string;
   colo?: string;
   account_id?: string;
   product_id?: string;
-  path?: string;
 }
 
-interface Stats {
-  requestCount: number;
-  broadcastCount: number;
-  windowStart: number;
-  seenLocations: Set<string>;
+// One datacenter's activity within the current window.
+interface ColoStats {
+  n: number;
+  products: Map<string, number>;
 }
-
 
 export class LocationHub extends DurableObject<Env> {
-  private stats: Stats = {
-    requestCount: 0,
-    broadcastCount: 0,
-    windowStart: Date.now(),
-    seenLocations: new Set(),
-  };
+  private colos = new Map<string, ColoStats>();
+  private requestCount = 0;
   private alarmScheduled = false;
   private sentIdle = false;
   private emitInterval: number;
-  private maxBroadcasts: number;
+  private maxProducts: number;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.emitInterval = parseInt(env.EMIT_INTERVAL_MS) || 500;
-    this.maxBroadcasts = parseInt(env.MAX_BROADCASTS_PER_EMIT) || 25;
+    this.maxProducts = parseInt(env.MAX_PRODUCTS_PER_COLO) || 5;
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -74,46 +67,21 @@ export class LocationHub extends DurableObject<Env> {
   }
 
   private async handleLocation(request: Request): Promise<Response> {
-    const location: LocationEvent = await request.json();
+    const event: LocationEvent = await request.json();
 
-    // Anonymize to ~1km precision (city-level)
-    location.lat = Math.round(location.lat * 100) / 100;
-    location.lon = Math.round(location.lon * 100) / 100;
-
-    const now = Date.now();
-    if (now - this.stats.windowStart >= this.emitInterval) {
-      this.stats = {
-        requestCount: 0,
-        broadcastCount: 0,
-        windowStart: now,
-        seenLocations: new Set(),
-      };
-    }
-
-    this.stats.requestCount++;
-    this.sentIdle = false;
-
-    // Deduplicate: one event per unique anonymized location per window
-    const locationKey = `${location.lat},${location.lon}`;
-    if (this.stats.seenLocations.has(locationKey)) {
-      this.ensureAlarm();
+    // No datacenter → can't place it on the globe; drop it.
+    if (!event.colo) {
       return new Response("ok");
     }
-    this.stats.seenLocations.add(locationKey);
 
-    // Sample: only broadcast if under the ceiling
-    if (this.stats.broadcastCount < this.maxBroadcasts) {
-      this.stats.broadcastCount++;
-      const message = JSON.stringify({ type: "location", data: location });
-      for (const ws of this.ctx.getWebSockets()) {
-        try {
-          ws.send(message);
-        } catch {
-          // Client disconnected, cleaned up in webSocketClose
-        }
-      }
-    }
+    const colo = this.colos.get(event.colo) ?? { n: 0, products: new Map() };
+    colo.n++;
+    const product = `${event.account_id ?? ""}/${event.product_id ?? ""}`;
+    colo.products.set(product, (colo.products.get(product) ?? 0) + 1);
+    this.colos.set(event.colo, colo);
 
+    this.requestCount++;
+    this.sentIdle = false;
     this.ensureAlarm();
     return new Response("ok");
   }
@@ -132,43 +100,41 @@ export class LocationHub extends DurableObject<Env> {
     this.alarmScheduled = false;
     const clients = this.ctx.getWebSockets();
 
-    if (clients.length > 0) {
-      const hasActivity = this.stats.requestCount > 0;
+    // Nobody watching → let the alarm stop (re-armed on next connect/POST).
+    if (clients.length === 0) {
+      this.colos.clear();
+      this.requestCount = 0;
+      return;
+    }
 
-      // Send stats if there's activity, or once when going idle
-      if (hasActivity || !this.sentIdle) {
-        const statsMessage = JSON.stringify({
-          type: "stats",
-          data: {
-            requestsPerSecond: this.stats.requestCount,
-            broadcastsPerSecond: this.stats.broadcastCount,
-            viewers: clients.length,
-          },
-        });
+    const hasActivity = this.colos.size > 0;
 
-        for (const ws of clients) {
-          try {
-            ws.send(statsMessage);
-          } catch {
-            // Cleaned up in webSocketClose
-          }
+    // Emit while there's activity, plus one final tick when going idle so the
+    // globe can fade out, then stay quiet until activity resumes.
+    if (hasActivity || !this.sentIdle) {
+      const message = JSON.stringify({
+        type: "tick",
+        requestsPerWindow: this.requestCount,
+        viewers: clients.length,
+        locations: buildLocs(this.colos, this.maxProducts),
+      });
+
+      for (const ws of clients) {
+        try {
+          ws.send(message);
+        } catch {
+          // Cleaned up in webSocketClose
         }
-
-        this.sentIdle = !hasActivity;
       }
 
-      // Reset for next window
-      this.stats = {
-        requestCount: 0,
-        broadcastCount: 0,
-        windowStart: Date.now(),
-        seenLocations: new Set(),
-      };
-
-      // Keep alarm running while clients are connected
-      await this.ctx.storage.setAlarm(Date.now() + this.emitInterval);
-      this.alarmScheduled = true;
+      this.sentIdle = !hasActivity;
     }
+
+    // Reset for the next window and keep the alarm running while clients remain.
+    this.colos.clear();
+    this.requestCount = 0;
+    await this.ctx.storage.setAlarm(Date.now() + this.emitInterval);
+    this.alarmScheduled = true;
   }
 
   async webSocketMessage(

--- a/workers/public-log-stream/tsconfig.json
+++ b/workers/public-log-stream/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "allowJs": true,
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,

--- a/workers/public-log-stream/wrangler.toml
+++ b/workers/public-log-stream/wrangler.toml
@@ -16,7 +16,7 @@ new_sqlite_classes = ["LocationHub"]
 
 [vars]
 EMIT_INTERVAL_MS = "500"
-MAX_BROADCASTS_PER_EMIT = "25"
+MAX_PRODUCTS_PER_COLO = "5"
 CORS_ORIGIN = "*"
 
 [env.staging]
@@ -26,7 +26,7 @@ routes = [
 
 [env.staging.vars]
 EMIT_INTERVAL_MS = "500"
-MAX_BROADCASTS_PER_EMIT = "25"
+MAX_PRODUCTS_PER_COLO = "5"
 CORS_ORIGIN = "*"
 
 [[env.staging.durable_objects.bindings]]


### PR DESCRIPTION
## What

Rework the `public-log-stream` worker so the live globe shows **per-datacenter activity** instead of a stream of individual requests.

Today the worker broadcasts one WebSocket message per request — deduped by *requester* cell, capped at 25 per window — and carries requester geolocation it never uses (the globe positions dots by Cloudflare `colo`, not requester coords). That drops activity beyond the cap and throws away the per-datacenter request volume we actually want to show.

## How

Aggregate by `colo` within each 500ms window and emit **one** batched `tick`:

```jsonc
{ "type": "tick",
  "requestsPerWindow": 142,
  "viewers": 37,
  "locations": [
    { "colo": "EWR", "n": 88, "p": [["nasa/landsat", 60], ["esa/sentinel-2", 28]] },
    { "colo": "LHR", "n": 54, "p": [["usgs/3dep", 54]] }
  ]
}
```

- One entry per active datacenter, with request count (`n`) and top-5 products (`p`).
- No coordinates and **no requester geolocation** in the payload — the frontend already maps `colo → lat/lon`. Privacy improves and the payload shrinks.
- Naturally bounded (~300 colos exist; tens active), so no cap needed.

Net **−90/+116 lines**: deletes the requester-cell dedup set, the `windowStart` drift bookkeeping, and the per-event send loop.

## Companion change

Frontend must adopt the `tick` format — see the source.coop PR. The Rust proxy needs **no change**; it already POSTs `colo` / `account_id` / `product_id`.

## Testing

- New `node --test` self-check on the pure aggregation helper (top-K product sort + per-colo shaping): 3/3 pass.
- Full Rust proxy suite green (unchanged by this worker-only edit).
- `tsc` not run locally (worker has no `node_modules`); types reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)