### PR TITLE
fix(sts): bound the AssumeRoleWithWebIdentity call with a request timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,17 @@ fn jwks_cache() -> JwksCache {
         .clone()
 }
 
+/// Bound the outbound STS `AssumeRoleWithWebIdentity` call. Without it a slow or
+/// hung federation lets the whole request stall until the Cloudflare edge kills
+/// it with a non-XML `error code: NNNN` body, which the caller's AWS SDK can't
+/// deserialize ("char 'e' is not expected.:1:1"). With the bound, a stall instead
+/// returns a proper S3 `ServiceUnavailable` XML error (HttpError → BackendError
+/// → 503) the client can parse and retry. STS normally answers in well under a
+/// second, so this only trips on genuine stalls — which only happen on a cold
+/// isolate, since the OIDC provider caches credentials across requests once warm.
+// ponytail: fixed 10s; promote to an env var if a deployment ever needs to tune it.
+const STS_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// [`HttpExchange`] for outbound STS calls, backed by the shared reqwest client
 /// (reqwest wraps `web_sys::fetch` on wasm). This is what lets the OIDC
 /// backend-auth middleware POST `AssumeRoleWithWebIdentity` to AWS STS.
@@ -80,6 +91,7 @@ impl HttpExchange for FetchHttpExchange {
             .client
             .post(url)
             .form(form)
+            .timeout(STS_REQUEST_TIMEOUT)
             .send()
             .await
             .map_err(|e| OidcProviderError::HttpError(e.to_string()))?;


### PR DESCRIPTION
## Problem

Loading a **private** product occasionally fails with an unparseable contents-load error, then self-heals after a few reloads. The app-side symptom is the AWS S3 SDK throwing:

```
Error: char 'e' is not expected.:1:1
Deserialization error: ... '$metadata': [Object]
```

## Root cause

Private products federate to AWS STS on the cold path: the OIDC backend-auth middleware POSTs `AssumeRoleWithWebIdentity` over the shared `reqwest` client, which is built with `Client::new()` — **no timeout** (`src/lib.rs`).

If that STS exchange stalls, the whole Worker request hangs until the **Cloudflare edge** terminates it and returns a non-XML `error code: NNNN` plaintext body. The caller's AWS S3 SDK tries to parse that as XML and chokes on byte 1 (`char 'e' is not expected.:1:1`). Nothing in the proxy/multistore Rust emits an `e`-leading body — every proxy response is `<?xml …>`-prefixed XML — so the `e` body originates at the edge, not in our code.

**Why it self-heals + why only private products:** the OIDC provider caches credentials across requests in a warm isolate, so STS only runs on a **cold isolate / cache miss** — exactly when it's slowest. Subsequent reloads hit a warm isolate with cached creds and skip STS entirely. Public/unlisted products list anonymously and never take this path.

## Fix

Bound the STS POST with a **10s per-request timeout**. reqwest's wasm/`fetch` backend honors `RequestBuilder::timeout()` via `AbortController`, so this works on the Workers runtime (the wasm `ClientBuilder` has no `.timeout()`, hence per-request).

On a stall the call now returns `OidcProviderError::HttpError` → `ProxyError::BackendError` → a proper **`503 ServiceUnavailable`** S3 XML error the client can parse and retry, instead of an opaque edge-timeout body. STS normally answers in well under a second, so the bound only trips on genuine stalls.

## Scope / caveats

- Covers **only** the STS exchange — the one outbound call this repo builds directly. The Source API connection-resolve and the backend S3 call go through other clients (`SourceCoopRegistry` / `object_store`) and aren't bounded here; if stalls are observed there too, they'd need separate timeouts.
- This is a mitigation that converts an unparseable failure into a clean, retryable S3 error. The complementary app-side change (degrade a contents-listing failure to an inline "try again" notice while keeping product metadata + the Edit link) is handled in `source.coop`.
- Timeout is a fixed const; trivially promotable to an env var (à la `STS_MAX_SESSION_DURATION`) if a deployment needs to tune it.

## Verification

`cargo fmt --check`, `cargo clippy --target wasm32-unknown-unknown -- -D warnings`, `cargo check --target wasm32-unknown-unknown`, and `cargo test` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)