### PR TITLE
test(deps): preview build against multistore cross-request-body-io fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#b3fc487038ec7c3b55d6f73c095482d68a3f30fb"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#b3fc487038ec7c3b55d6f73c095482d68a3f30fb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#b3fc487038ec7c3b55d6f73c095482d68a3f30fb"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#b3fc487038ec7c3b55d6f73c095482d68a3f30fb"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#b3fc487038ec7c3b55d6f73c095482d68a3f30fb"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#718ee732259a95ede3afcdf7a654d83abeb69e4b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fbuffered-body-size-guard#d827cbc402841dde2c589153f219040d7ac0bb51"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
 dependencies = [
  "async-trait",
  "base64",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
 dependencies = [
  "async-trait",
  "bytes",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
 dependencies = [
  "base64",
  "chrono",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.2"
-source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#56b84877e68c0948bf532fd48ce56b286b5f34df"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,8 +909,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce59de8d7e3456f9d9bbd47842f520b9142fd28991a6c7bd484846620fb206d"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
 dependencies = [
  "async-trait",
  "base64",
@@ -937,8 +936,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a27bb8b8a8da696e0671c563e1772f4099924f62fb522a636455d25c6bb814"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -962,8 +960,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1c6ac0fed7225d1d6fb84981a360d727dc99ab2d0b51960cc404ef47a91c59"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
 dependencies = [
  "base64",
  "chrono",
@@ -982,8 +979,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d603d78607332a71f0a38af203bc25ae11214d90e6ddedff8147888f1da276"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -993,8 +989,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0354c742b40c4a0883636c8bd0840cb2e3d24284055e9e91b90a3899b4ff1452"
+source = "git+https://github.com/developmentseed/multistore?branch=fix%2Fcross-request-body-io#c755997b4443843847840eadba73b4e633706f0b"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,15 +77,18 @@ web-sys = { version = "0.3", features = [
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
 
-# TEMPORARY: build against the cross-request-body-io fix branch of multistore
-# until it ships in a release. Fixes 500/503 "Cannot perform I/O on behalf of a
-# different request" on multipart/batch-delete writes under a cold-isolate burst
-# (developmentseed/multistore#100). All five multistore* crates must resolve
-# from the same git source or their shared types won't unify. Remove this block
-# and bump the multistore* deps once the fix is released.
+# TEMPORARY: build against the multistore cross-request-body-io fix, which is
+# merged to main (#100) but not yet released. The fix/buffered-body-size-guard
+# branch carries main + the #102 review follow-ups (size guard before the
+# buffered-op read, fail-closed on classifier over-match), so it's the complete
+# un-released set. Fixes 500/503 "Cannot perform I/O on behalf of a different
+# request" on multipart/batch-delete writes under a cold-isolate burst. All five
+# multistore* crates must resolve from the same git source or their shared types
+# won't unify. Remove this block and bump the multistore* deps once it ships in a
+# release.
 [patch.crates-io]
-multistore = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
+multistore = { git = "https://github.com/developmentseed/multistore", branch = "fix/buffered-body-size-guard" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "fix/buffered-body-size-guard" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "fix/buffered-body-size-guard" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "fix/buffered-body-size-guard" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "fix/buffered-body-size-guard" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,16 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.4", features = ["http"] }
 worker-macros = { version = "=0.7.4", features = ["http"] }
+
+# TEMPORARY: build against the cross-request-body-io fix branch of multistore
+# until it ships in a release. Fixes 500/503 "Cannot perform I/O on behalf of a
+# different request" on multipart/batch-delete writes under a cold-isolate burst
+# (developmentseed/multistore#100). All five multistore* crates must resolve
+# from the same git source or their shared types won't unify. Remove this block
+# and bump the multistore* deps once the fix is released.
+[patch.crates-io]
+multistore = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "fix/cross-request-body-io" }


### PR DESCRIPTION
**Draft / temporary — not for merge.** Exists to deploy a preview for end-to-end verification of the multistore fix.

## What this does

Adds a temporary `[patch.crates-io]` block pointing all five `multistore*` crates at the **`fix/cross-request-body-io`** branch (developmentseed/multistore#100). No app code changes — only `Cargo.toml` + `Cargo.lock`.

## What the multistore fix does

Resolves intermittent **500/503** failures on multipart and batch-delete writes under a cold-isolate burst:

```
[ERROR] multistore::proxy: failed to read request body
  error=arrayBuffer await failed: Cannot perform I/O on behalf of a different request
```

Root cause: the inbound body was read via `array_buffer()` *after* the bucket-lookup and STS awaits; `wasm-bindgen-futures`' shared microtask queue can resume that read under another concurrent request's I/O context. The fix:

- **Plain `UploadPart`** now streams (`UNSIGNED-PAYLOAD` header signing, checksums forwarded+signed) instead of buffering — never materialized.
- **Small multipart-control / batch-delete bodies** are read at the top of `handle_request`, in the request's own I/O context, before any cross-request await.

## How to verify on the preview

Point the source.coop frontend at this deployment and exercise the cases that reproduced the error:

- A **large batch of object deletes** (the original report).
- A **multipart upload of large objects** (e.g. the `euro-test` Zarr writes) — UploadParts and the multipart control ops.

Expect no `Cannot perform I/O on behalf of a different request` (500/503) on the opening burst, and parts/deletes to complete.

## Cleanup

Revert this commit and bump the `multistore*` deps once developmentseed/multistore#100 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)