### PR TITLE
fix(sigv4): use encoded request path for inbound signature verification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,18 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         tracing::info_span!("request", %request_id, method = %parts.method, path = %parts.path);
     let _guard = span.enter();
 
+    // SigV4's canonical URI is the percent-encoded path the client signed over.
+    // `RequestParts` decodes the path for bucket/key routing, so recover the raw
+    // encoded path from the request URL for signature verification — otherwise a
+    // key with an escaped character (e.g. a space → `%20`) fails with
+    // SignatureDoesNotMatch. `Uri::path()` returns the path un-decoded; fall back
+    // to the decoded signing path if the URL somehow won't parse.
+    let signing_path = req
+        .url()
+        .parse::<http::Uri>()
+        .map(|u| u.path().to_string())
+        .unwrap_or_else(|_| rewrite.signing_path.clone());
+
     let request_info = RequestInfo::new(
         &parts.method,
         &rewrite.path,
@@ -285,7 +297,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         &parts.headers,
         None,
     )
-    .with_signing_path(&rewrite.signing_path)
+    .with_signing_path(&signing_path)
     .with_signing_query(rewrite.signing_query.as_deref());
 
     let start_ms = js_sys::Date::now();

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -135,3 +135,17 @@ fn url_encoded_prefix() {
         Some("list-type=2&prefix=admin%20boundaries/subdir/".to_string())
     );
 }
+
+// ── Signing-path encoding (http::Uri) ───────────────────────────────
+// The proxy recovers the raw, percent-encoded request path from the URL for
+// SigV4 signature verification: `RequestParts` decodes the path for routing,
+// but the client signs the *encoded* path, so a decoded key with a space breaks
+// the signature (SignatureDoesNotMatch). This pins the `http` crate behavior the
+// fix relies on — `Uri::path()` must return the path WITHOUT decoding `%20`.
+#[test]
+fn uri_path_preserves_percent_encoding() {
+    let uri: http::Uri = "https://data.staging.source.coop/acct/prod/foo%20bar?x-id=PutObject"
+        .parse()
+        .unwrap();
+    assert_eq!(uri.path(), "/acct/prod/foo%20bar");
+}


### PR DESCRIPTION
## Problem

Uploading an object whose key contains a character the client percent-escapes — e.g. a space (`foo bar` → `foo%20bar`) — fails with `403 SignatureDoesNotMatch`:

```
[WARN] multistore::auth::sigv4: SigV4 signature mismatch
canonical_request=PUT
/alukach/upload-tests/foo bar     <-- literal space
...
```

## Root cause

SigV4's canonical URI is the **percent-encoded** path the client signed. `RequestParts::from_web_sys` decodes the request path (correct for bucket/key routing — `operation.key()` needs the decoded `foo bar`), and we were passing that same **decoded** path as the `signing_path`. So the server rebuilt its canonical request with a literal space while the client (aws-sdk-js) signed `%20` → signatures never match.

The outbound leg was already correct: `build_backend_url` hands the decoded key to `url::Url::parse`, which re-encodes the space to `%20` consistently for both the forwarded request and its signature.

## Fix

Recover the raw encoded path from the request URL via `http::Uri::path()` (which does not decode) and use it as the signing path. Routing/bucket-key parsing keeps the decoded path. Handles all escaped characters, not just spaces; falls back to the decoded path if the URL won't parse.

## Tests

- New characterization test in `tests/routing.rs` pinning the `http` behavior the fix relies on (`Uri::path()` preserves `%20`).
- Full native suite + wasm `clippy`/`check` pass via the pre-commit hook.

⚠️ Verified locally only (the fetch handler is wasm-only and can't be unit-tested natively). Needs a staging deploy to confirm the real `foo bar` upload now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)