### PR TITLE
chore(audit): ignore quick-xml DoS advisories pending upstream fix

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -46,4 +46,32 @@ ignore = [
     # transitive deps (`rsa`, `quinn-proto`, `object_store`) upgrade to
     # `rand` 0.10+.
     "RUSTSEC-2026-0097",
+
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: denial-of-service in `quick-xml`
+    # XML parsing (quadratic duplicate-attribute check; unbounded
+    # namespace-declaration allocation in `NsReader`). Patched only in
+    # quick-xml >= 0.41.0.
+    #
+    # We pull vulnerable quick-xml transitively via `object_store` (and via
+    # `multistore`, which pins the same majors). No semver-compatible upgrade
+    # path exists: object_store 0.13.x requires `^0.39.0` and even the latest
+    # object_store 0.14.0 requires `^0.40.1` — both below the 0.41.0 fix — so
+    # `cargo update` cannot reach a patched release anywhere in the tree.
+    #
+    # Impact here is bounded:
+    #
+    # 1. The vulnerable parser only processes XML *responses from configured
+    #    storage backends* (S3/Azure list and multipart responses), not
+    #    arbitrary client input. Triggering it requires a data connection
+    #    pointing at a hostile endpoint.
+    #
+    # 2. Both advisories are resource-exhaustion DoS, and the parse runs
+    #    inside a Cloudflare Workers invocation with hard per-request CPU and
+    #    memory limits — a poisoned response fails that one request; it cannot
+    #    take down the service.
+    #
+    # Revisit when: object_store ships a release on quick-xml >= 0.41 and
+    # multistore adopts it — then remove these ignores and `cargo update`.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
Fixes the failing **Security Audit** CI job ([example run](https://github.com/source-cooperative/data.source.coop/actions/runs/29129716866/job/86482554646)).

`cargo audit` fails on two quick-xml denial-of-service advisories:

- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic run time checking a start tag for duplicate attribute names
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) — unbounded namespace-declaration allocation in `NsReader`

Both are patched only in quick-xml **>= 0.41.0**, and no dependency upgrade can get us there: vulnerable quick-xml enters via `object_store`, whose 0.13.x line requires `^0.39.0` and whose latest release (0.14.0) requires `^0.40.1` — both semver-incompatible with the fix. `cargo update` has no patched release to resolve to anywhere in the tree.

This PR documents and ignores the two advisories in `.cargo/audit.toml`, following the same pattern already used there for the `rsa` Marvin Attack and `rand` unsoundness advisories (unfixable upstream, justified, with revisit criteria).

Why the exposure is acceptable in the interim:

1. The vulnerable parser only processes XML responses from **configured storage backends** (S3/Azure list and multipart responses), not arbitrary client input — triggering it requires a data connection pointed at a hostile endpoint.
2. Both advisories are resource-exhaustion DoS, and parsing runs inside a Cloudflare Workers invocation with hard per-request CPU/memory limits — a poisoned response fails that single request and cannot take down the service.

**Revisit when** object_store ships a release on quick-xml >= 0.41 and multistore adopts it: remove the ignores and `cargo update`.

Verified locally: `cargo audit` now exits clean with only the pre-existing allowed warning (`anyhow` RUSTSEC-2026-0190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)