### PR TITLE
feat(sts): accept ARN-shaped alias for the _default role

### DIFF
--- a/src/sts.rs
+++ b/src/sts.rs
@@ -63,10 +63,25 @@ impl CredentialRegistry for StsCredentialRegistry {
         // individual repositories can define custom roles with fine-grained
         // scope and subject restrictions (e.g. per-repo CI/CD access).
         // For now, only the hardcoded `_default` role is supported.
-        if role_id == "_default" {
+        if is_default_role(role_id) {
             Ok(Some(self.default_role.clone()))
         } else {
             Ok(None)
         }
     }
+}
+
+/// Whether `role_id` names the `_default` role — literally, or via an
+/// ARN-shaped alias whose resource is `role/_default` (any partition/account,
+/// e.g. `arn:aws:iam::000000000000:role/_default`).
+///
+/// The alias exists because AWS SDKs validate `RoleArn` client-side (ARN shape,
+/// 20-character minimum) before the request is ever sent, so a bare `_default`
+/// can't reach the server from standard tooling. Accepting the alias keeps
+/// `/.sts` a drop-in `AssumeRoleWithWebIdentity` target for unmodified SDKs
+/// (see source-cooperative/data.source.coop#184). Same role, same trust model —
+/// only the name is longer; the partition/account portion is ignored rather
+/// than validated because it carries no meaning here.
+pub(crate) fn is_default_role(role_id: &str) -> bool {
+    role_id == "_default" || (role_id.starts_with("arn:") && role_id.ends_with(":role/_default"))
 }

--- a/tests/sts.rs
+++ b/tests/sts.rs
@@ -1,0 +1,44 @@
+//! Native unit tests for the `_default` role alias in `sts`, included via
+//! `#[path]` (the lib itself is `cdylib` with `test = false`). Mirrors the
+//! pattern in `tests/backend_auth.rs`.
+
+#[path = "../src/sts.rs"]
+mod sts;
+
+use sts::is_default_role;
+
+#[test]
+fn literal_default_accepted() {
+    assert!(is_default_role("_default"));
+}
+
+#[test]
+fn arn_alias_accepted_for_any_partition_and_account() {
+    assert!(is_default_role("arn:aws:iam::000000000000:role/_default"));
+    assert!(is_default_role("arn:aws:iam::123456789012:role/_default"));
+    assert!(is_default_role(
+        "arn:aws-us-gov:iam::123456789012:role/_default"
+    ));
+}
+
+#[test]
+fn other_roles_rejected() {
+    assert!(!is_default_role(""));
+    assert!(!is_default_role("_other"));
+    assert!(!is_default_role("default"));
+    assert!(!is_default_role("arn:aws:iam::123456789012:role/other"));
+}
+
+#[test]
+fn alias_requires_arn_prefix_and_exact_resource() {
+    // No arn: prefix.
+    assert!(!is_default_role("role/_default"));
+    // Pathed resource is not the `_default` role.
+    assert!(!is_default_role(
+        "arn:aws:iam::123456789012:role/team/_default"
+    ));
+    // `_default` as a suffix of another role name.
+    assert!(!is_default_role(
+        "arn:aws:iam::123456789012:role/not_default"
+    ));
+}


### PR DESCRIPTION
Refs #184 — the data.source.coop half of making `/.sts` a drop-in `AssumeRoleWithWebIdentity` replacement for AWS STS.

## Why

AWS SDKs validate `RoleArn` **client-side** (ARN shape, 20-character minimum) before any request is sent — botocore raises `ParamValidationError` on `RoleArn=_default` — so standard tooling (SDK web-identity credential providers, `aws-actions/configure-aws-credentials`) can never reach `/.sts` with the role's literal name.

## What

`get_role` now accepts any `arn:*…:role/_default` (e.g. `arn:aws:iam::000000000000:role/_default`) as an alias for the hardcoded `_default` role. Same role, same trust model — only the name is longer. The partition/account portion is ignored rather than validated because it carries no meaning here. The exact-resource check rejects pathed (`role/team/_default`) and suffix (`role/not_default`) lookalikes.

The bare `_default` keeps working, so existing clients (including `tests/test_writes.py` on #183) are unaffected.

## Remaining half

AWS SDK STS clients send parameters as a form-encoded POST **body**, which the multistore-sts handler doesn't parse yet (query string only). That fix lands in [developmentseed/multistore](https://github.com/developmentseed/multistore); once released, bumping the dependency here completes #184.

## Verification

`cargo test --test sts` — 4 new unit tests covering the literal name, alias across partitions/accounts, and lookalike rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk6VMBuKNcTK3boS8HrdQs