### PR TITLE
fix(gcs): pass bucket_name to multistore GCS store

### DIFF
--- a/src/source_api/registry.rs
+++ b/src/source_api/registry.rs
@@ -256,7 +256,8 @@ async fn resolve_product(
 /// Map a connection's raw `provider` to its multistore `backend_type`
 /// (`s3`/`az`/`gcs`) and the provider-specific `backend_options`. Doing the
 /// provider match once keeps the type and its options in a single source of
-/// truth. (`gcs` carries no options yet.)
+/// truth. The GCS arm sets `bucket_name` (multistore's GCS store requires it,
+/// same as the s3 arm).
 fn build_backend_options(
     details: &DataConnectionDetails,
 ) -> Result<(String, HashMap<String, String>), ProxyError> {
@@ -284,7 +285,12 @@ fn build_backend_options(
             }
             "az"
         }
-        "gcs" | "gs" => "gcs",
+        "gcs" | "gs" => {
+            if let Some(ref bucket) = details.bucket {
+                options.insert("bucket_name".to_string(), bucket.clone());
+            }
+            "gcs"
+        }
         other => {
             return Err(ProxyError::Internal(format!(
                 "unsupported provider: {}",


### PR DESCRIPTION
## Problem

GCS-backed products 500 on every request in staging:

```
config error: failed to build GCS paginated store: Generic GCS error: Missing bucket name
status=500, s3_code=InternalError
```

The provider now resolves correctly (`backend_type=gcs`), but `build_backend_options` returned the `gcs` backend type with an **empty options map** — it never set `bucket_name`, which multistore's GCS store requires (`bucket_name`, `service_account_key`, `skip_signature` — see multistore `types.rs`). The `s3` arm already inserts `bucket_name` from `connection.details.bucket`; the `gcs` arm was missing the equivalent line.

## Fix

Mirror the `s3` arm: insert `bucket_name` from `details.bucket` in the `gcs` arm.

## Testing

- `cargo test` (all native suites) + wasm build/clippy green via pre-commit hook.
- Manual staging verification of a GCS list/HEAD recommended after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)