### PR TITLE
feat(sts): accept AssumeRoleWithWebIdentity from form-encoded POST bodies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     let config = load_config(&env);
 
     // ── Parse request ──────────────────────────────────────────────
-    let (mut parts, js_body) = RequestParts::from_web_sys(&req)
+    let (mut parts, mut js_body) = RequestParts::from_web_sys(&req)
         .map_err(|e| worker::Error::RustError(format!("invalid request: {e}")))?;
 
     // The router matches `/.sts` exactly; a trailing-slash variant would
@@ -130,6 +130,20 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     if parts.path == "/.sts/" {
         parts.path.pop();
     }
+
+    // AWS SDKs send query-protocol operations — STS `AssumeRoleWithWebIdentity`
+    // among them — as a form-encoded POST body with no query string at all, and
+    // the STS route handler reads its parameters from `RequestInfo::form_body`.
+    // Collect that body up front or SDK clients fall through to the S3 pipeline
+    // unhandled. A no-op passthrough for every other request shape (and for a
+    // form POST with a missing or oversized `Content-Length`, which is streamed
+    // rather than buffered into WASM memory), and the returned body is rebuilt
+    // from the collected bytes so a mislabeled S3 write — `Content-Type` is
+    // client-controlled — still reaches the gateway with its payload intact.
+    js_body = parts
+        .absorb_form_body(js_body)
+        .await
+        .map_err(|e| worker::Error::RustError(format!("invalid request body: {e}")))?;
 
     let request_id = extract_request_id(&parts.headers);
 
@@ -310,7 +324,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         None,
     )
     .with_signing_path(&signing_path)
-    .with_signing_query(rewrite.signing_query.as_deref());
+    .with_signing_query(rewrite.signing_query.as_deref())
+    .with_form_body(parts.form_body.as_deref());
 
     let start_ms = js_sys::Date::now();
     let response = gateway

--- a/tests/test_writes.py
+++ b/tests/test_writes.py
@@ -53,16 +53,19 @@ needs_wrong_aud_token = pytest.mark.skipif(
 )
 
 
-def sts_exchange(token):
-    """POST /.sts with the given web identity token; return the raw response."""
-    return requests.post(
-        f"{PROXY_URL}/.sts",
-        params={
-            "Action": "AssumeRoleWithWebIdentity",
-            "RoleArn": "_default",
-            "WebIdentityToken": token,
-        },
-    )
+def sts_exchange(token, *, form_body=False):
+    """POST /.sts with the given web identity token; return the raw response.
+
+    `form_body` sends the parameters the way AWS SDKs do — form-encoded in the
+    request body, with no query string — instead of in the query string."""
+    params = {
+        "Action": "AssumeRoleWithWebIdentity",
+        "RoleArn": "_default",
+        "WebIdentityToken": token,
+    }
+    if form_body:
+        return requests.post(f"{PROXY_URL}/.sts", data=params)
+    return requests.post(f"{PROXY_URL}/.sts", params=params)
 
 
 @functools.lru_cache(maxsize=1)
@@ -201,6 +204,33 @@ def test_sts_exchange_issues_credentials():
     assert access_key.startswith("STSPRXY")
     assert secret_key
     assert session_token
+
+
+@needs_token
+def test_sts_exchange_accepts_a_form_encoded_body():
+    """The same exchange, sent the way an AWS SDK sends it: parameters
+    form-encoded in the POST body rather than in the query string."""
+    resp = sts_exchange(ID_TOKEN, form_body=True)
+    assert resp.status_code == 200, (
+        f"form-encoded /.sts exchange failed ({resp.status_code}): {resp.text[:300]}"
+    )
+    fields = {el.tag.rpartition("}")[2]: el.text for el in ET.fromstring(resp.text).iter()}
+    assert fields["AccessKeyId"].startswith("STSPRXY")
+
+
+def test_sts_form_encoded_body_reaches_the_sts_handler():
+    """Routing check that needs no identity token: a form-encoded POST must be
+    dispatched to STS — which then rejects this token — rather than falling
+    through to the S3 pipeline. Without the body being collected before
+    dispatch, the STS handler never sees the `Action` param and never matches,
+    so the failure mode is a non-STS error rather than a 200."""
+    resp = sts_exchange("not-a-jwt", form_body=True)
+    assert resp.status_code == 400, (
+        f"expected an STS rejection ({resp.status_code}): {resp.text[:300]}"
+    )
+    assert "InvalidIdentityToken" in resp.text, (
+        f"request did not reach the STS handler: {resp.text[:300]}"
+    )
 
 
 @needs_token


### PR DESCRIPTION
AWS SDKs send query-protocol operations as a form-encoded `POST` body with no query string at all, but the worker only ever surfaced the query string to the router. The STS handler reads its parameters from `RequestInfo::form_body`, which stayed `None`, so every SDK-shaped request fell through to the S3 pipeline.

multistore 0.7.0 ([developmentseed/multistore#112](https://github.com/developmentseed/multistore/pull/112), pulled in by #190) added `RequestParts::absorb_form_body` for exactly this. The dep bump alone does not enable it — the runtime has to call it, which is what this PR does.

## Behavior

`POST /.sts` with `Action=AssumeRoleWithWebIdentity&RoleArn=_default&WebIdentityToken=…` in the body:

| | before | after |
|---|---|---|
| response | 400 `InvalidRequest: unsupported POST operation` | routed to the STS handler |

Verified locally against `wrangler dev` with the stub API and a throwaway OIDC key, rebuilding the worker each way to confirm the difference is this change and not a stale isolate.

## Safety

`absorb_form_body` is a no-op passthrough for every request shape that is not a form-encoded `POST`, and it rebuilds the body from the collected bytes — so a mislabeled S3 write (`Content-Type` is client-controlled: `CompleteMultipartUpload`, `DeleteObjects`) still reaches the gateway with its payload intact. Collection is skipped entirely for a form `POST` with a missing or oversized `Content-Length` rather than buffering it into WASM memory.

## Tests

- `test_sts_form_encoded_body_reaches_the_sts_handler` — needs no identity token, so it runs on fork PRs. Asserts the response is an STS rejection (`InvalidIdentityToken`) rather than the S3 fall-through; the status code alone does not discriminate, since both are 400. Fails on `main`.
- `test_sts_exchange_accepts_a_form_encoded_body` — the positive path, under the existing `needs_token` gate.

Full local integration run: 24 passed, 11 skipped (credentialed tier, no GitHub OIDC token locally).

## Scope

Part of #184. This is one of the two blockers for a true SDK drop-in; the other is #185 — AWS SDKs validate `RoleArn` client-side (min 20 chars), so `_default` is rejected before the request is ever sent. Both are needed before `boto3.client("sts", endpoint_url=…)` works unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)