### PR TITLE
fix(s3): adapt CopyObject to multistore's copy-source path mapping

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -47,9 +47,37 @@ jobs:
     if: vars.FEDERATION_TEST_ACCOUNT != '' && vars.FEDERATION_TEST_PRODUCT != '' && vars.FEDERATION_TEST_KEY != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Mints the caller identity for the copy-source authz test; see below.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - name: Mint caller identity token (GitHub OIDC)
+        # A GitHub Actions OIDC token, minted per run — short-lived by design
+        # and never stored, unlike a token parked in a repo secret.
+        #
+        # Dormant until Source registers GitHub as a valid IdP, so that products
+        # can accept writes from GitHub Actions. Two things must land first:
+        # the deployment's AUTH_ISSUER must accept GitHub's issuer (today it is
+        # a single Ory URL — src/config.rs reads AUTH_ISSUER as one String,
+        # unlike the comma-separated AUTH_AUDIENCE, so this needs a code change
+        # too), and the audience Source expects must be set as
+        # FEDERATION_TEST_AUDIENCE. Until then no token is minted and the
+        # copy-source authz test skips; the rest of the suite is unaffected.
+        if: vars.FEDERATION_TEST_AUDIENCE != ''
+        run: |
+          set -euo pipefail
+          token=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ vars.FEDERATION_TEST_AUDIENCE }}" \
+            | jq -r '.value')
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "::error::FEDERATION_TEST_AUDIENCE is set but minting returned no token"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "CI_WRITE_ID_TOKEN=$token" >> "$GITHUB_ENV"
       - name: Run federation smoke tests
         env:
           PROXY_URL: ${{ needs.deploy.outputs.deploy_url }}
@@ -58,14 +86,8 @@ jobs:
           FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
           FEDERATION_RESTRICTED_PRODUCT: ${{ vars.FEDERATION_RESTRICTED_PRODUCT }}
           FEDERATION_WRITE_PRODUCT: ${{ vars.FEDERATION_WRITE_PRODUCT }}
-          # No CI_WRITE_ID_TOKEN is supplied, so the copy-source authz test
-          # skips here. Wiring one is a design decision that hasn't been made:
-          # this job talks to the *deployed* worker, whose AUTH_ISSUER is Ory,
-          # so the token must come from that issuer — and an Ory ID token is
-          # short-lived, so it cannot simply be parked in a repo secret. It
-          # needs a step that mints one per run from a durable credential
-          # (a service-account client_id/secret or refresh token). See the
-          # CI_WRITE_ID_TOKEN notes in tests/test_federation.py.
+          # Set by the mint step above, and only when it runs.
+          CI_WRITE_ID_TOKEN: ${{ env.CI_WRITE_ID_TOKEN }}
         # boto3: the copy-source authz test signs SigV4 through the AWS SDK
         # rather than hand-rolling requests.
         run: uvx --with requests --with boto3 pytest tests/test_federation.py -v

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,14 +58,14 @@ jobs:
           FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
           FEDERATION_RESTRICTED_PRODUCT: ${{ vars.FEDERATION_RESTRICTED_PRODUCT }}
           FEDERATION_WRITE_PRODUCT: ${{ vars.FEDERATION_WRITE_PRODUCT }}
-          # Caller identity for the copy-source authz test. NOT a GitHub OIDC
-          # token: this job talks to the *deployed* worker, whose AUTH_ISSUER is
-          # Ory (https://auth.staging.source.coop), so a GitHub-minted token
-          # fails issuer verification no matter its audience. Must be issued by
-          # that issuer, with an `aud` among staging's AUTH_AUDIENCE client_ids
-          # (see wrangler.toml [env.staging.vars]) and a subject holding write
-          # on FEDERATION_WRITE_PRODUCT. Unset, that one test skips.
-          CI_WRITE_ID_TOKEN: ${{ secrets.FEDERATION_CALLER_TOKEN }}
+          # No CI_WRITE_ID_TOKEN is supplied, so the copy-source authz test
+          # skips here. Wiring one is a design decision that hasn't been made:
+          # this job talks to the *deployed* worker, whose AUTH_ISSUER is Ory,
+          # so the token must come from that issuer — and an Ory ID token is
+          # short-lived, so it cannot simply be parked in a repo secret. It
+          # needs a step that mints one per run from a durable credential
+          # (a service-account client_id/secret or refresh token). See the
+          # CI_WRITE_ID_TOKEN notes in tests/test_federation.py.
         # boto3: the copy-source authz test signs SigV4 through the AWS SDK
         # rather than hand-rolling requests.
         run: uvx --with requests --with boto3 pytest tests/test_federation.py -v

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -47,32 +47,9 @@ jobs:
     if: vars.FEDERATION_TEST_ACCOUNT != '' && vars.FEDERATION_TEST_PRODUCT != '' && vars.FEDERATION_TEST_KEY != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      # Only used to mint the caller identity for the copy-source authz test,
-      # and only when FEDERATION_TEST_AUDIENCE is set (see below).
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - name: Mint caller identity token (GitHub OIDC)
-        # Dormant like the rest of this job: the copy-source authz test needs a
-        # caller the *deployed* worker will accept, so the audience must match
-        # that deployment's AUTH_AUDIENCE — which is not CI's
-        # `source-data-proxy-ci`. Left unset, no token is minted and that one
-        # test skips; the rest of the suite is unaffected.
-        if: vars.FEDERATION_TEST_AUDIENCE != ''
-        run: |
-          set -euo pipefail
-          token=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ vars.FEDERATION_TEST_AUDIENCE }}" \
-            | jq -r '.value')
-          if [ -z "$token" ] || [ "$token" = "null" ]; then
-            echo "::error::FEDERATION_TEST_AUDIENCE is set but minting returned no token"
-            exit 1
-          fi
-          echo "::add-mask::$token"
-          echo "CI_WRITE_ID_TOKEN=$token" >> "$GITHUB_ENV"
       - name: Run federation smoke tests
         env:
           PROXY_URL: ${{ needs.deploy.outputs.deploy_url }}
@@ -81,6 +58,14 @@ jobs:
           FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
           FEDERATION_RESTRICTED_PRODUCT: ${{ vars.FEDERATION_RESTRICTED_PRODUCT }}
           FEDERATION_WRITE_PRODUCT: ${{ vars.FEDERATION_WRITE_PRODUCT }}
+          # Caller identity for the copy-source authz test. NOT a GitHub OIDC
+          # token: this job talks to the *deployed* worker, whose AUTH_ISSUER is
+          # Ory (https://auth.staging.source.coop), so a GitHub-minted token
+          # fails issuer verification no matter its audience. Must be issued by
+          # that issuer, with an `aud` among staging's AUTH_AUDIENCE client_ids
+          # (see wrangler.toml [env.staging.vars]) and a subject holding write
+          # on FEDERATION_WRITE_PRODUCT. Unset, that one test skips.
+          CI_WRITE_ID_TOKEN: ${{ secrets.FEDERATION_CALLER_TOKEN }}
         # boto3: the copy-source authz test signs SigV4 through the AWS SDK
         # rather than hand-rolling requests.
         run: uvx --with requests --with boto3 pytest tests/test_federation.py -v

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -47,9 +47,32 @@ jobs:
     if: vars.FEDERATION_TEST_ACCOUNT != '' && vars.FEDERATION_TEST_PRODUCT != '' && vars.FEDERATION_TEST_KEY != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Only used to mint the caller identity for the copy-source authz test,
+      # and only when FEDERATION_TEST_AUDIENCE is set (see below).
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - name: Mint caller identity token (GitHub OIDC)
+        # Dormant like the rest of this job: the copy-source authz test needs a
+        # caller the *deployed* worker will accept, so the audience must match
+        # that deployment's AUTH_AUDIENCE — which is not CI's
+        # `source-data-proxy-ci`. Left unset, no token is minted and that one
+        # test skips; the rest of the suite is unaffected.
+        if: vars.FEDERATION_TEST_AUDIENCE != ''
+        run: |
+          set -euo pipefail
+          token=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ vars.FEDERATION_TEST_AUDIENCE }}" \
+            | jq -r '.value')
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "::error::FEDERATION_TEST_AUDIENCE is set but minting returned no token"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "CI_WRITE_ID_TOKEN=$token" >> "$GITHUB_ENV"
       - name: Run federation smoke tests
         env:
           PROXY_URL: ${{ needs.deploy.outputs.deploy_url }}
@@ -57,4 +80,7 @@ jobs:
           FEDERATION_TEST_PRODUCT: ${{ vars.FEDERATION_TEST_PRODUCT }}
           FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
           FEDERATION_RESTRICTED_PRODUCT: ${{ vars.FEDERATION_RESTRICTED_PRODUCT }}
-        run: uvx --with requests pytest tests/test_federation.py -v
+          FEDERATION_WRITE_PRODUCT: ${{ vars.FEDERATION_WRITE_PRODUCT }}
+        # boto3: the copy-source authz test signs SigV4 through the AWS SDK
+        # rather than hand-rolling requests.
+        run: uvx --with requests --with boto3 pytest tests/test_federation.py -v

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,8 +1035,7 @@ dependencies = [
 [[package]]
 name = "multistore"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10553bb6d41a7caf40663151d2ebb73f0032bed3474031bb69c81ce8a0a46b39"
+source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
 dependencies = [
  "async-trait",
  "base64",
@@ -1064,8 +1063,7 @@ dependencies = [
 [[package]]
 name = "multistore-cf-workers"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cb288f2d08ba9fa1b1970e3323266da7cee51dea786d3be6c73cbb85ebeac6"
+source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1091,8 +1089,7 @@ dependencies = [
 [[package]]
 name = "multistore-oidc-provider"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b743bc10e0fdfb5c70f9f302e0bf756714b7e09cfd41d837918425db3c6b36eb"
+source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
 dependencies = [
  "base64",
  "chrono",
@@ -1111,8 +1108,7 @@ dependencies = [
 [[package]]
 name = "multistore-path-mapping"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ce2241c2cdd6bbbf239498ec7caa9a4488b28c159f58288261435b4f090975"
+source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1122,8 +1118,7 @@ dependencies = [
 [[package]]
 name = "multistore-sts"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8407b2bc78eeadd420fc6c952cc9c6ac5f51c7e52643417d3ea048859cdad2"
+source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,8 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.7.0"
-source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ea59297a4aac2cbea49e6e55320f6cc5d974cd167337afc9dfcc1b386bd3f4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1062,8 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.7.0"
-source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23afaa6c9ecc498314858a3a2c2600b4880ffa8c4f0f3339cb2a86c8b70e857"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1088,8 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.7.0"
-source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a3ee043aa16fbbca9b324e001865d9d7e3c1fb55041106cf8d8c52b452f95d"
 dependencies = [
  "base64",
  "chrono",
@@ -1107,8 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.7.0"
-source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fd87532e2f48fa4496597012735c05dd4cdfcb3e9517d8c5cfa89e5cd20e4e"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1117,8 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.7.0"
-source = "git+https://github.com/developmentseed/multistore?branch=main#8261ebef3f2a984c68c576f552ede3201acdaa82"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e89dd8f5e7755359eaf9d9ba94a30ed69cc2a5b067ccc53c61a8a28b10fd044"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ path = "tests/fixtures.rs"
 
 [dependencies]
 # Multistore
-multistore = { version = "0.7.0", features = ["azure", "gcp"] }
-multistore-oidc-provider = "0.7.0"
-multistore-path-mapping = "0.7.0"
-multistore-sts = "0.7.0"
+multistore = { version = "0.7.1", features = ["azure", "gcp"] }
+multistore-oidc-provider = "0.7.1"
+multistore-path-mapping = "0.7.1"
+multistore-sts = "0.7.1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -67,7 +67,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 # ring is transitive (via object_store); this direct entry only turns the
 # feature on for the wasm target.
 ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"] }
-multistore-cf-workers = { version = "0.7.0", features = ["azure", "gcp"] }
+multistore-cf-workers = { version = "0.7.1", features = ["azure", "gcp"] }
 # On wasm32-unknown-unknown reqwest selects its browser `fetch` backend by
 # target arch (not a cargo feature), so the default TLS/backend features are
 # unnecessary here. The `form` feature gates `.form()`, which the STS
@@ -87,12 +87,3 @@ web-sys = { version = "0.3", features = [
 worker = { version = "=0.7.5", features = ["http"] }
 worker-macros = { version = "=0.7.5", features = ["http"] }
 
-# ponytail: temporary — exercise the unreleased CopyObject fixes queued for
-# multistore 0.7.1 (developmentseed/multistore#128, #129). Drop this block once
-# 0.7.1 is published; the version requirements above already accept it.
-[patch.crates-io]
-multistore = { git = "https://github.com/developmentseed/multistore", branch = "main" }
-multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "main" }
-multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "main" }
-multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "main" }
-multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,13 @@ web-sys = { version = "0.3", features = [
 ] }
 worker = { version = "=0.7.5", features = ["http"] }
 worker-macros = { version = "=0.7.5", features = ["http"] }
+
+# ponytail: temporary — exercise the unreleased CopyObject fixes queued for
+# multistore 0.7.1 (developmentseed/multistore#128, #129). Drop this block once
+# 0.7.1 is published; the version requirements above already accept it.
+[patch.crates-io]
+multistore = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-cf-workers = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-oidc-provider = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-path-mapping = { git = "https://github.com/developmentseed/multistore", branch = "main" }
+multistore-sts = { git = "https://github.com/developmentseed/multistore", branch = "main" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,18 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         .map(|u| u.path().to_string())
         .unwrap_or_else(|_| rewrite.signing_path.clone());
 
+    // `CopyObject` names its source in `x-amz-copy-source` rather than the URL,
+    // in client coordinates (`/account/product/key`). The registry only knows
+    // mapped bucket names, so an unmapped source resolves to a bucket it has
+    // never heard of and every copy fails with 404 NoSuchBucket. The client
+    // signed that header, so it must not be mutated — the mapped value rides
+    // alongside it and signature verification still uses the header as sent.
+    let mapped_copy_source = parts
+        .headers
+        .get("x-amz-copy-source")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| mapping.rewrite_copy_source(v));
+
     let request_info = RequestInfo::new(
         &parts.method,
         &rewrite.path,
@@ -325,7 +337,8 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     )
     .with_signing_path(&signing_path)
     .with_signing_query(rewrite.signing_query.as_deref())
-    .with_form_body(parts.form_body.as_deref());
+    .with_form_body(parts.form_body.as_deref())
+    .with_copy_source(mapped_copy_source.as_deref());
 
     let start_ms = js_sys::Date::now();
     let response = gateway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     .with_signing_path(&signing_path)
     .with_signing_query(rewrite.signing_query.as_deref())
     .with_form_body(parts.form_body.as_deref())
-    ;// TEETH-CHECK: with_copy_source removed on purpose
+    .with_copy_source(mapped_copy_source.as_deref());
 
     let start_ms = js_sys::Date::now();
     let response = gateway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use multistore_oidc_provider::{HttpExchange, OidcCredentialProvider, OidcProvide
 use multistore_path_mapping::{MappedRegistry, PathMapping};
 use multistore_sts::jwks::JwksCache;
 use multistore_sts::route_handler::StsRouterExt;
-use object_path::{extract_path_segments, is_keyless_write};
+use object_path::{extract_path_segments, is_keyless_write, mapped_copy_source};
 use std::sync::OnceLock;
 use sts::StsCredentialRegistry;
 use worker::{event, Context, Env, Result};
@@ -316,17 +316,10 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         .map(|u| u.path().to_string())
         .unwrap_or_else(|_| rewrite.signing_path.clone());
 
-    // `CopyObject` names its source in `x-amz-copy-source` rather than the URL,
-    // in client coordinates (`/account/product/key`). The registry only knows
-    // mapped bucket names, so an unmapped source resolves to a bucket it has
-    // never heard of and every copy fails with 404 NoSuchBucket. The client
-    // signed that header, so it must not be mutated — the mapped value rides
-    // alongside it and signature verification still uses the header as sent.
-    let mapped_copy_source = parts
-        .headers
-        .get("x-amz-copy-source")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| mapping.rewrite_copy_source(v));
+    // See `object_path::mapped_copy_source`: the copy source must be mapped
+    // into the registry's namespace, without mutating the header the client
+    // signed over.
+    let copy_source = mapped_copy_source(&parts.headers, &mapping);
 
     let request_info = RequestInfo::new(
         &parts.method,
@@ -338,7 +331,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     .with_signing_path(&signing_path)
     .with_signing_query(rewrite.signing_query.as_deref())
     .with_form_body(parts.form_body.as_deref())
-    .with_copy_source(mapped_copy_source.as_deref());
+    .with_copy_source(copy_source.as_deref());
 
     let start_ms = js_sys::Date::now();
     let response = gateway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
     .with_signing_path(&signing_path)
     .with_signing_query(rewrite.signing_query.as_deref())
     .with_form_body(parts.form_body.as_deref())
-    .with_copy_source(mapped_copy_source.as_deref());
+    ;// TEETH-CHECK: with_copy_source removed on purpose
 
     let start_ms = js_sys::Date::now();
     let response = gateway

--- a/src/object_path.rs
+++ b/src/object_path.rs
@@ -23,6 +23,32 @@ pub(crate) fn extract_path_segments(path: &str) -> (Option<&str>, Option<&str>, 
     (account, product, key)
 }
 
+/// Map an inbound `x-amz-copy-source` header into the registry's namespace.
+///
+/// `CopyObject` names its source in a header rather than the URL, in client
+/// coordinates (`/{account}/{product}/{key}`). The registry only knows mapped
+/// bucket names (`account:product`), so an unmapped source resolves to a bucket
+/// it has never heard of and the copy fails with 404 NoSuchBucket. The client
+/// signed the header, so it must not be mutated — the mapped value produced
+/// here is passed alongside it via `RequestInfo::with_copy_source`, and
+/// signature verification keeps using the header as sent.
+///
+/// Returns `None` when there is no copy-source header (the request isn't a
+/// copy) or when the value can't be mapped — too few segments to name an
+/// object, or not valid UTF-8. `None` leaves multistore reading the header
+/// as-is, which is the correct fallback: a non-copy request has nothing to map,
+/// and an unmappable source should fail on its own merits rather than on a
+/// silently-invented bucket name.
+pub(crate) fn mapped_copy_source(
+    headers: &http::HeaderMap,
+    mapping: &multistore_path_mapping::PathMapping,
+) -> Option<String> {
+    headers
+        .get("x-amz-copy-source")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| mapping.rewrite_copy_source(v))
+}
+
 /// Whether `method` writes to a single object but `path` carries no object key.
 ///
 /// `PUT`/`DELETE` (PutObject/DeleteObject) address one object, so they need a

--- a/tests/object_path.rs
+++ b/tests/object_path.rs
@@ -6,7 +6,81 @@
 mod object_path;
 
 use http::Method;
-use object_path::{extract_path_segments, is_keyless_write};
+use object_path::{extract_path_segments, is_keyless_write, mapped_copy_source};
+
+/// The deployment's real mapping: `/{account}/{product}/{key}` folds the first
+/// two segments into the internal bucket `account:product`.
+fn mapping() -> multistore_path_mapping::PathMapping {
+    multistore_path_mapping::PathMapping {
+        bucket_segments: 2,
+        bucket_separator: ":".to_string(),
+        display_bucket_segments: 1,
+    }
+}
+
+fn headers(copy_source: Option<&str>) -> http::HeaderMap {
+    let mut h = http::HeaderMap::new();
+    if let Some(v) = copy_source {
+        h.insert("x-amz-copy-source", v.parse().unwrap());
+    }
+    h
+}
+
+/// The whole point: a client-coordinate copy source (`/account/product/key`)
+/// becomes a registry-coordinate one (`account:product/key`). Without this the
+/// source names a bucket the registry has never heard of and the copy 404s.
+#[test]
+fn copy_source_is_folded_into_the_internal_bucket_name() {
+    assert_eq!(
+        mapped_copy_source(&headers(Some("/acct/prod/README.md")), &mapping()),
+        Some("/acct:prod/README.md".to_string())
+    );
+    // Leading slash is optional in `x-amz-copy-source`; both forms map alike.
+    assert_eq!(
+        mapped_copy_source(&headers(Some("acct/prod/README.md")), &mapping()),
+        Some("/acct:prod/README.md".to_string())
+    );
+    // Nested keys keep every segment past the bucket.
+    assert_eq!(
+        mapped_copy_source(&headers(Some("/acct/prod/a/b/c.txt")), &mapping()),
+        Some("/acct:prod/a/b/c.txt".to_string())
+    );
+}
+
+/// `versionId` rides along untouched — multistore#129 authorizes the source
+/// against that version, so losing it here would silently copy the wrong one.
+/// Percent-encoding is likewise preserved rather than decoded.
+#[test]
+fn copy_source_preserves_version_and_encoding() {
+    assert_eq!(
+        mapped_copy_source(
+            &headers(Some("/acct/prod/a%20b.txt?versionId=v42")),
+            &mapping()
+        ),
+        Some("/acct:prod/a%20b.txt?versionId=v42".to_string())
+    );
+}
+
+/// No header means the request isn't a copy: nothing to map, and multistore
+/// must be left reading the (absent) header itself rather than handed a value.
+#[test]
+fn absent_copy_source_maps_to_none() {
+    assert_eq!(mapped_copy_source(&headers(None), &mapping()), None);
+}
+
+/// Too few segments to name an object inside a product. Mapping these would
+/// invent a bucket name; `None` lets them fail on their own merits instead.
+#[test]
+fn unmappable_copy_source_maps_to_none() {
+    assert_eq!(
+        mapped_copy_source(&headers(Some("/acct/prod")), &mapping()),
+        None
+    );
+    assert_eq!(
+        mapped_copy_source(&headers(Some("/acct")), &mapping()),
+        None
+    );
+}
 
 #[test]
 fn extract_splits_account_product_key() {

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -26,8 +26,17 @@ deployed worker once the ``FEDERATION_TEST_*`` repo variables are set:
                              reads its private backend)
   FEDERATION_WRITE_PRODUCT   product id, in the same account, that the caller
                              identified by CI_WRITE_ID_TOKEN may *write*. Used
-                             only by the copy-source authorization test, which
-                             also needs that token (see test_writes.py)
+                             only by the copy-source authorization test
+  CI_WRITE_ID_TOKEN          that caller's identity token. Unlike in ci.yml,
+                             this is NOT a GitHub Actions OIDC token: these
+                             tests hit a deployed worker whose AUTH_ISSUER is
+                             Ory (e.g. https://auth.staging.source.coop), so a
+                             GitHub-minted token fails issuer verification
+                             whatever its audience. It must come from that
+                             issuer, carry an ``aud`` among the deployment's
+                             AUTH_AUDIENCE client_ids (wrangler.toml
+                             ``[env.staging.vars]``), and belong to a subject
+                             holding write on FEDERATION_WRITE_PRODUCT
 """
 
 import os
@@ -98,8 +107,8 @@ def test_restricted_product_denied_to_anonymous():
     not (ACCOUNT and RESTRICTED_PRODUCT and WRITE_PRODUCT and ID_TOKEN),
     reason=(
         "copy-source authz target not configured (set FEDERATION_TEST_ACCOUNT/"
-        "FEDERATION_RESTRICTED_PRODUCT/FEDERATION_WRITE_PRODUCT and "
-        "CI_WRITE_ID_TOKEN against a deployed proxy)"
+        "FEDERATION_RESTRICTED_PRODUCT/FEDERATION_WRITE_PRODUCT and an "
+        "issuer-appropriate CI_WRITE_ID_TOKEN against a deployed proxy)"
     ),
 )
 def test_copy_source_authorization_is_enforced():

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -36,7 +36,13 @@ deployed worker once the ``FEDERATION_TEST_*`` repo variables are set:
                              issuer, carry an ``aud`` among the deployment's
                              AUTH_AUDIENCE client_ids (wrangler.toml
                              ``[env.staging.vars]``), and belong to a subject
-                             holding write on FEDERATION_WRITE_PRODUCT
+                             holding write on FEDERATION_WRITE_PRODUCT.
+                             Not yet wired into staging.yml: an Ory ID token is
+                             short-lived, so it cannot be parked in a repo
+                             secret — supplying it needs a step that mints one
+                             per run from a durable credential (a
+                             service-account client_id/secret or a refresh
+                             token). Until that exists this test skips
 """
 
 import os

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -27,22 +27,22 @@ deployed worker once the ``FEDERATION_TEST_*`` repo variables are set:
   FEDERATION_WRITE_PRODUCT   product id, in the same account, that the caller
                              identified by CI_WRITE_ID_TOKEN may *write*. Used
                              only by the copy-source authorization test
-  CI_WRITE_ID_TOKEN          that caller's identity token. Unlike in ci.yml,
-                             this is NOT a GitHub Actions OIDC token: these
-                             tests hit a deployed worker whose AUTH_ISSUER is
-                             Ory (e.g. https://auth.staging.source.coop), so a
-                             GitHub-minted token fails issuer verification
-                             whatever its audience. It must come from that
-                             issuer, carry an ``aud`` among the deployment's
-                             AUTH_AUDIENCE client_ids (wrangler.toml
-                             ``[env.staging.vars]``), and belong to a subject
-                             holding write on FEDERATION_WRITE_PRODUCT.
-                             Not yet wired into staging.yml: an Ory ID token is
-                             short-lived, so it cannot be parked in a repo
-                             secret — supplying it needs a step that mints one
-                             per run from a durable credential (a
-                             service-account client_id/secret or a refresh
-                             token). Until that exists this test skips
+  CI_WRITE_ID_TOKEN          that caller's identity token — a GitHub Actions
+                             OIDC token, minted per run by staging.yml (short-
+                             lived by design, never stored) once
+                             FEDERATION_TEST_AUDIENCE is set.
+
+                             Dormant until Source registers GitHub as a valid
+                             IdP so products can accept writes from GitHub
+                             Actions. That needs the deployment's AUTH_ISSUER to
+                             accept GitHub's issuer — today it is a single Ory
+                             URL, and ``src/config.rs`` reads AUTH_ISSUER as one
+                             String (unlike the comma-separated AUTH_AUDIENCE),
+                             so it is a code change as well as config — and the
+                             audience Source expects to be set as
+                             FEDERATION_TEST_AUDIENCE. Until then this test
+                             skips. The caller must also hold write on
+                             FEDERATION_WRITE_PRODUCT
 """
 
 import os

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -24,6 +24,10 @@ deployed worker once the ``FEDERATION_TEST_*`` repo variables are set:
                              same account, used by the authz/confused-deputy test
                              (an anonymous caller must be denied before federation
                              reads its private backend)
+  FEDERATION_WRITE_PRODUCT   product id, in the same account, that the caller
+                             identified by CI_WRITE_ID_TOKEN may *write*. Used
+                             only by the copy-source authorization test, which
+                             also needs that token (see test_writes.py)
 """
 
 import os
@@ -36,6 +40,8 @@ ACCOUNT = os.environ.get("FEDERATION_TEST_ACCOUNT")
 PRODUCT = os.environ.get("FEDERATION_TEST_PRODUCT")
 KEY = os.environ.get("FEDERATION_TEST_KEY")
 RESTRICTED_PRODUCT = os.environ.get("FEDERATION_RESTRICTED_PRODUCT")
+WRITE_PRODUCT = os.environ.get("FEDERATION_WRITE_PRODUCT")
+ID_TOKEN = os.environ.get("CI_WRITE_ID_TOKEN")
 
 
 @pytest.mark.skipif(
@@ -85,4 +91,50 @@ def test_restricted_product_denied_to_anonymous():
     assert resp.status_code in (401, 403, 404), (
         "anonymous caller was not denied a restricted federated product "
         f"(status {resp.status_code}); federation may have served private data"
+    )
+
+
+@pytest.mark.skipif(
+    not (ACCOUNT and RESTRICTED_PRODUCT and WRITE_PRODUCT and ID_TOKEN),
+    reason=(
+        "copy-source authz target not configured (set FEDERATION_TEST_ACCOUNT/"
+        "FEDERATION_RESTRICTED_PRODUCT/FEDERATION_WRITE_PRODUCT and "
+        "CI_WRITE_ID_TOKEN against a deployed proxy)"
+    ),
+)
+def test_copy_source_authorization_is_enforced():
+    """The confused-deputy guard for `CopyObject`: holding write on the
+    destination must not let a caller read a product they aren't entitled to.
+
+    A copy is authorized in two halves — the destination as a write, the source
+    as a synthetic `GetObject`. This names a source the caller cannot read and a
+    destination they can write, so only the source half can deny it. A success
+    would mean CopyObject is a hole around product authorization: read any
+    restricted product by copying it somewhere readable.
+
+    Deliberately here and not in the CI integration tier, where it could not
+    fail: federation is attempted against the destination before the source is
+    resolved, so on CI's throwaway signing key every copy dies at federation
+    first — and `AccessDenied` is itself one of the federation error codes, so
+    the assertion below would pass without proving anything. It needs a
+    deployment where the destination write genuinely succeeds, which is what
+    this suite provides.
+    """
+    import botocore.exceptions
+
+    from test_writes import s3_client  # /.sts exchange + SigV4, see its module docstring
+
+    client = s3_client(retries={"max_attempts": 1})
+    # A success raises nothing and fails here as DID NOT RAISE — the outcome
+    # this test exists to catch.
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        client.copy_object(
+            Bucket=ACCOUNT,
+            Key=f"{WRITE_PRODUCT}/copy-authz-probe.txt",
+            CopySource=f"{ACCOUNT}/{RESTRICTED_PRODUCT}/{KEY or 'any-key'}",
+        )
+    status = exc.value.response["ResponseMetadata"]["HTTPStatusCode"]
+    assert status in (401, 403, 404), (
+        f"copy from a restricted source was not denied (status {status}); "
+        "CopyObject may be bypassing source authorization"
     )

--- a/tests/test_writes.py
+++ b/tests/test_writes.py
@@ -342,6 +342,53 @@ def test_federated_write_fails_closed(op):
     )
 
 
+def test_anonymous_copy_is_denied():
+    """A copy is a write, so it dies at the authz gate without credentials —
+    before any source resolution or backend call."""
+    resp = requests.put(
+        f"{PROXY_URL}/{WRITE_ACCOUNT}/{WRITE_PRODUCT}/copy-dest.txt",
+        headers={
+            "x-amz-copy-source": f"/{WRITE_ACCOUNT}/{WRITE_PRODUCT}/{HIVE_KEY_DIR}/src.pmtiles"
+        },
+    )
+    assert resp.status_code == 403
+
+
+@needs_token
+def test_copy_source_is_path_mapped():
+    """multistore#128 wiring pin: `x-amz-copy-source` names its source in
+    client coordinates (`/account/product/key`), but the registry only knows
+    mapped bucket names. Unless the proxy passes the *mapped* source alongside
+    the client-signed header (`RequestInfo::with_copy_source`), the source
+    resolves to a bucket the registry has never heard of and every copy dies
+    as 404 NoSuchBucket — long before the backend is consulted.
+
+    So the assertion is on the failure *mode*, not on success: CI's throwaway
+    signing key means federation can never succeed here (see
+    test_federated_write_fails_closed), but a copy that reaches the federation
+    seam at all proves the source resolved. NoSuchBucket/NoSuchKey means the
+    mapping regressed."""
+    import botocore.exceptions
+
+    client = s3_client(retries={"max_attempts": 1})
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        client.copy_object(
+            Bucket=WRITE_ACCOUNT,
+            Key=f"{WRITE_PRODUCT}/{HIVE_KEY_DIR}/copy-dest.pmtiles",
+            CopySource=f"{WRITE_ACCOUNT}/{WRITE_PRODUCT}/{HIVE_KEY_DIR}/copy-src.pmtiles",
+        )
+    code = exc.value.response["Error"].get("Code")
+    assert code, "unparseable error response"
+    assert code not in {"NoSuchBucket", "NotImplemented"}, (
+        f"{code}: the copy source was not mapped into the registry's namespace "
+        "— is RequestInfo::with_copy_source still wired up in src/lib.rs?"
+    )
+    assert code not in {"SignatureDoesNotMatch", "InvalidRequest"}, (
+        f"{code}: the client-signed x-amz-copy-source header was mutated; only "
+        "the out-of-band mapped value may differ from what the client sent"
+    )
+
+
 @needs_token
 def test_corrupted_session_token_rejected():
     """A SigV4 request whose sealed SessionToken has been tampered with must

--- a/tests/test_writes.py
+++ b/tests/test_writes.py
@@ -355,19 +355,18 @@ def test_anonymous_copy_is_denied():
 
 
 @needs_token
-def test_copy_source_is_path_mapped():
-    """multistore#128 wiring pin: `x-amz-copy-source` names its source in
-    client coordinates (`/account/product/key`), but the registry only knows
-    mapped bucket names. Unless the proxy passes the *mapped* source alongside
-    the client-signed header (`RequestInfo::with_copy_source`), the source
-    resolves to a bucket the registry has never heard of and every copy dies
-    as 404 NoSuchBucket — long before the backend is consulted.
+def test_copy_reaches_the_federation_seam():
+    """A credentialed CopyObject is parsed and dispatched as a copy, and fails
+    closed at federation like every other write — a bounded, parseable S3
+    error rather than a hang or a silent success.
 
-    So the assertion is on the failure *mode*, not on success: CI's throwaway
-    signing key means federation can never succeed here (see
-    test_federated_write_fails_closed), but a copy that reaches the federation
-    seam at all proves the source resolved. NoSuchBucket/NoSuchKey means the
-    mapping regressed."""
+    Scope, measured rather than assumed: this does NOT pin the copy-source
+    path mapping. Federation is attempted against the destination before the
+    source is resolved, so a copy fails identically here whether or not
+    `RequestInfo::with_copy_source` is wired up — verified by deleting the
+    wiring and watching this test still pass. The mapping's real regression
+    test is native: `copy_source_is_folded_into_the_internal_bucket_name` in
+    tests/object_path.rs, which does fail without it."""
     import botocore.exceptions
 
     client = s3_client(retries={"max_attempts": 1})
@@ -379,13 +378,11 @@ def test_copy_source_is_path_mapped():
         )
     code = exc.value.response["Error"].get("Code")
     assert code, "unparseable error response"
-    assert code not in {"NoSuchBucket", "NotImplemented"}, (
-        f"{code}: the copy source was not mapped into the registry's namespace "
-        "— is RequestInfo::with_copy_source still wired up in src/lib.rs?"
-    )
-    assert code not in {"SignatureDoesNotMatch", "InvalidRequest"}, (
-        f"{code}: the client-signed x-amz-copy-source header was mutated; only "
-        "the out-of-band mapped value may differ from what the client sent"
+    # NotImplemented would mean the copy was rejected as a cross-store copy;
+    # SignatureDoesNotMatch would mean the client-signed x-amz-copy-source
+    # header got mutated instead of the mapped value being passed alongside it.
+    assert code not in {"NotImplemented", "SignatureDoesNotMatch", "InvalidRequest"}, (
+        f"{code}: rejected before the federation seam this test pins"
     )
 
 


### PR DESCRIPTION
Bumps multistore to 0.7.1 and adapts this proxy to the copy-source handling it introduces.

## Why

`CopyObject` names its source in the `x-amz-copy-source` header rather than the URL, in client coordinates (`/account/product/key`). This deployment is path-mapped, so the registry only knows mapped bucket names (`account:product`) — an unmapped source resolves to a bucket it has never heard of and the copy fails with 404 NoSuchBucket. That affects the server-side CopyObject support landed in 97d5121.

multistore 0.7.1 provides the mechanism for this ([#128](https://github.com/developmentseed/multistore/pull/128)), but it is opt-in: `RequestInfo::with_copy_source` takes a mapped value that the host app must supply. This wires it up.

The bump also picks up [#129](https://github.com/developmentseed/multistore/pull/129), which authorizes a versioned copy-source against its version.

## Changes

- `Cargo.toml` / `Cargo.lock` — multistore crates to 0.7.1, from crates.io with checksums.
- `object_path::mapped_copy_source` — maps the header through `PathMapping::rewrite_copy_source`, returning `None` for a non-copy request or an unmappable value. Lives in `object_path` because that module is deliberately wasm-free and so can be unit-tested natively, the lib being `cdylib` with `test = false`.
- `src/lib.rs` — passes the mapped value via `with_copy_source`. The client signed the original header, so it is left untouched and signature verification still uses it as sent; only the value passed alongside differs.

## Tests

The mapping is pinned natively in `tests/object_path.rs`: the account/product fold, leading-slash normalization, nested keys, `versionId` and percent-encoding preservation, and both `None` cases.

Natively rather than through an integration test, because an integration test cannot detect this regression: federation is attempted against the destination before the copy source is resolved, so in CI — where the throwaway signing key means federation never succeeds — a copy fails identically whether or not the mapping is wired up. This was verified, not assumed.

Copy-source authorization — a caller holding write on the destination must not be able to read a product they aren't entitled to via `CopyObject` — is asserted in `tests/test_federation.py`, the deployed-environment suite. Same reason: in CI the destination write never succeeds, and `AccessDenied` is itself a federation error code, so the assertion would pass without proving anything. It is dormant and skips until both `FEDERATION_WRITE_PRODUCT` and a caller token are supplied, and skips cleanly otherwise; `staging.yml` gains boto3, the `FEDERATION_WRITE_PRODUCT` passthrough, and a step minting the caller as a GitHub Actions OIDC token — short-lived and per-run, with nothing stored. This anticipates registering GitHub as a valid IdP with Source so products can accept writes from GitHub Actions.

It stays dormant until two things land: the deployment's `AUTH_ISSUER` must accept GitHub's issuer, which is a **code change and not only config** — `src/config.rs:80` reads `AUTH_ISSUER` as a single `String`, unlike the comma-separated `AUTH_AUDIENCE` at `src/config.rs:87` — and `FEDERATION_TEST_AUDIENCE` must name the audience Source expects. Until both, no token is minted and the test skips.

Two integration tests in `tests/test_writes.py` cover what that layer can genuinely show, CopyObject having had no coverage there at all: `test_anonymous_copy_is_denied` (a copy is a write, so it dies at the authz gate) and `test_copy_reaches_the_federation_seam` (a copy is parsed and dispatched as a copy, and fails closed).

## Verification

- `cargo test` — 73 pass across 8 suites (was 69)
- `cargo check --lib --target wasm32-unknown-unknown` — clean
- Local run against stub API + `wrangler dev`; credentialed tests need a GitHub OIDC token and run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)




