### PR TITLE
fix(observability): log 5xx responses at WARN

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,25 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
         .await
         .into_web_sys();
     let duration_ms = js_sys::Date::now() - start_ms;
-    tracing::info!(status = response.status(), duration_ms, "response");
+    let status = response.status();
+    tracing::info!(status, duration_ms, "response");
+
+    // Production runs at LOG_LEVEL=WARN, so the `info` line above — and the
+    // `info_span` carrying method/path — are both silenced. That leaves a 5xx
+    // with no worker-side record at all, which is how the edge-generated 520s on
+    // large streamed PUTs ended up undiagnosable: Cloudflare logs the URL and
+    // nothing else. Re-emit at WARN, with the span fields inlined since the span
+    // itself is disabled at this level.
+    if status >= 500 {
+        tracing::warn!(
+            status,
+            duration_ms,
+            method = %parts.method,
+            path = %parts.path,
+            content_length = header_str(&parts.headers, "content-length"),
+            "server error response"
+        );
+    }
 
     // ── Extract path segments (used by analytics + location broadcast) ──
     let (account, product, key) = extract_path_segments(&parts.path);


### PR DESCRIPTION
## Why

Production runs at `LOG_LEVEL=WARN`. The only response-level log is `tracing::info!(status, duration_ms, "response")`, and the `info_span!` carrying `method`/`path` is likewise disabled at that level. A 5xx therefore leaves **no worker-side record at all** — Cloudflare logs the request URL and nothing else.

That is why the current ~0.1% error rate is undiagnosable. In a sample of 24 failing events (20 large `tessera` PUTs, 2 `dynamical` LISTs), every one carries `truncated: false` with no worker logs attached. We cannot distinguish a stale multipart `uploadId` from expired federated credentials from a client that hung up mid-upload.

## What

Re-emit at WARN when `status >= 500`, with the span fields inlined (the span is disabled at this level) plus `content-length`, since the failures correlate with large streamed bodies.

## Scope

Observability only — no behavior change. This is deliberately the first step: the remaining hypotheses about the 520s live in the streamed-PUT path in `multistore-cf-workers` and cannot be confirmed without worker-side logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)