### PR TITLE
test(repro): minimal Workers reproducer for the streamed-PUT failures

### DIFF
--- a/tests/repro/streamed-put-io-context/.gitignore
+++ b/tests/repro/streamed-put-io-context/.gitignore
@@ -1,0 +1,3 @@
+build/
+target/
+Cargo.lock

--- a/tests/repro/streamed-put-io-context/Cargo.toml
+++ b/tests/repro/streamed-put-io-context/Cargo.toml
@@ -1,0 +1,35 @@
+# Standalone: deliberately not a member of the parent crate's build.
+[workspace]
+
+[package]
+name = "streamed-put-io-context"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+http = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+  "Headers",
+  "ReadableStream",
+  "Request",
+  "RequestInit",
+  "Response",
+  "ResponseInit",
+  "TransformStream",
+  "WritableStream",
+] }
+worker = { version = "=0.7.5", features = ["http"] }
+worker-macros = { version = "=0.7.5", features = ["http"] }
+
+[profile.release]
+opt-level = "s"
+lto = true

--- a/tests/repro/streamed-put-io-context/README.md
+++ b/tests/repro/streamed-put-io-context/README.md
@@ -1,0 +1,58 @@
+# Streamed-PUT failure reproducer
+
+Minimal Workers reproducer for the write-path failures behind the residual ~0.1%
+error rate on `data.source.coop`. No S3, no auth, no registry — the only variable
+is *when* the inbound request body stream is touched relative to an await.
+
+## What it does
+
+Two arms, same code path, selected by request path:
+
+| arm | behaviour | mirrors |
+| --- | --- | --- |
+| `/before` | attach the inbound stream to the outbound request **before** any await | `ProxyGateway::op_needs_buffered_body` — the multipart control ops and batch delete |
+| `/after` | await first (standing in for the registry lookup and the STS exchange), **then** attach the stream | `WorkerBackend::forward` for `PutObject` / `UploadPart`, which the classifier explicitly excludes |
+
+`forward()` copies `WorkerBackend::forward` faithfully, including the
+`FixedLengthStream` wrapper and its dropped `pipe_to` promise.
+
+## Running
+
+```sh
+python3 origin.py &                 # fake backend on :9101 (REPRO_SLOW_SECONDS tunes the await)
+worker-build --release
+npx wrangler@4 dev --port 8787 --local &
+python3 drive.py --concurrency 8 --rounds 4 --size-mib 16
+```
+
+`drive.py` exits non-zero if the post-await arm failed.
+
+## What it has actually shown
+
+At concurrency 8 × 4 rounds × 16 MiB it produced **1 failure in 32** on `/after`
+and **0 in 32** on `/before`:
+
+```
+[after] forward failed: Error: Network connection lost. - Cause: Error: Network connection lost.
+```
+
+client-side surfacing as `BrokenPipeError`. It is intermittent — a later run of
+96/96 on both arms was clean — so treat a green run as inconclusive, not as a fix.
+
+**Scope, honestly.** `Network connection lost` on the outbound fetch maps to
+`ProxyError::BackendError` → **503**. That is the *minority* prod failure mode
+(2 of 23 in one sample). It does **not** reproduce the majority 520 mode.
+
+In prod the 520 is *relayed from the backend fetch*: `GatewayResponse::Forward`
+passes the upstream status through verbatim (`response_from_forward`), the worker's
+own 5xx log records `status=520`, and `handle_request` returns normally. So for the
+520s the worker is not being killed — it is faithfully forwarding a 520 that the
+Worker→S3 subrequest produced. tessera's backend is plain S3 in us-west-2, which
+does not emit 520, so that status is synthesized by the runtime for a subrequest
+the worker itself issued. Why, is still open.
+
+The `TypeError: Can't read from request stream after responding with an exception`
+that accompanies the 520s fires ~1 ms *after* the response is committed. It is the
+orphaned `pipe_to` still reading the inbound body — a consequence, not the cause,
+but it is what destroys the connection so the client sees a reset instead of the
+relayed status.

--- a/tests/repro/streamed-put-io-context/drive.py
+++ b/tests/repro/streamed-put-io-context/drive.py
@@ -1,0 +1,87 @@
+"""Fire concurrent streamed PUTs at both arms of the reproducer and tally results.
+
+Usage:
+    python3 drive.py [--arm after|before|both] [--concurrency N] [--rounds N] [--size-mib N]
+
+Exit status is 1 if the `after` arm produced any failure, so this doubles as a
+regression check once the upstream fix lands.
+"""
+
+import argparse
+import collections
+import http.client
+import sys
+import threading
+
+WORKER_HOST = "127.0.0.1"
+WORKER_PORT = 8787
+
+
+def one_put(arm, size_bytes, results, lock):
+    payload = b"\0" * size_bytes
+    try:
+        conn = http.client.HTTPConnection(WORKER_HOST, WORKER_PORT, timeout=120)
+        # Explicit content-length: this is the FixedLengthStream branch, the
+        # same one a 16 MiB UploadPart takes.
+        conn.request(
+            "PUT",
+            f"/{arm}",
+            body=payload,
+            headers={"content-length": str(size_bytes)},
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8", "replace")[:300]
+        key = f"{resp.status} {body}" if resp.status != 200 else "200 ok"
+        conn.close()
+    except Exception as e:  # connection reset, etc. — the 520 analogue
+        key = f"EXC {type(e).__name__}: {e}"[:300]
+    with lock:
+        results[key] += 1
+
+
+def run(arm, concurrency, rounds, size_bytes):
+    results = collections.Counter()
+    lock = threading.Lock()
+    for _ in range(rounds):
+        threads = [
+            threading.Thread(target=one_put, args=(arm, size_bytes, results, lock))
+            for _ in range(concurrency)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    return results
+
+
+def report(arm, results):
+    total = sum(results.values())
+    bad = total - results.get("200 ok", 0)
+    print(f"\n=== /{arm} — {total} requests, {bad} failed ===")
+    for key, count in results.most_common():
+        print(f"  {count:4d}  {key}")
+    return bad
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--arm", default="both", choices=["after", "before", "both"])
+    p.add_argument("--concurrency", type=int, default=8)
+    p.add_argument("--rounds", type=int, default=4)
+    p.add_argument("--size-mib", type=int, default=16)
+    args = p.parse_args()
+
+    size = args.size_mib * 1024 * 1024
+    arms = ["before", "after"] if args.arm == "both" else [args.arm]
+
+    failures = {}
+    for arm in arms:
+        failures[arm] = report(arm, run(arm, args.concurrency, args.rounds, size))
+
+    print()
+    if failures.get("after"):
+        print("REPRODUCED: the post-await arm failed.")
+        if not failures.get("before"):
+            print("Control arm (pre-await) was clean — timing, not the stream itself.")
+        sys.exit(1)
+    print("No failures on the post-await arm.")

--- a/tests/repro/streamed-put-io-context/origin.py
+++ b/tests/repro/streamed-put-io-context/origin.py
@@ -1,0 +1,62 @@
+"""Fake backend for the reproducer: a body sink plus a deliberately slow endpoint.
+
+`/sink` swallows a streamed PUT and returns 200 — it stands in for S3.
+`/slow` sleeps, standing in for the Source API lookup and the STS exchange that
+the gateway awaits between capturing the request body and forwarding it. The
+sleep is what keeps several requests parked on an await at once, which is the
+condition under which the shared wasm-bindgen executor can poll one request's
+future while workerd's current I/O context belongs to another.
+
+Threaded on purpose: a single-threaded server would serialize the proxy's
+requests and destroy the concurrency the bug needs.
+"""
+
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("REPRO_ORIGIN_PORT", "9101"))
+SLOW_SECONDS = float(os.environ.get("REPRO_SLOW_SECONDS", "0.25"))
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        if self.path.startswith("/slow"):
+            time.sleep(SLOW_SECONDS)
+            return self._send(200, b"slow-done")
+        return self._send(404, b"")
+
+    def do_PUT(self):
+        # Drain the body so the client side of the pipe completes normally.
+        remaining = int(self.headers.get("content-length") or 0)
+        if remaining:
+            while remaining > 0:
+                chunk = self.rfile.read(min(remaining, 1 << 20))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+        else:
+            # Chunked / unknown length: read to EOF of this message.
+            self.rfile.read()
+        return self._send(200, b"sunk")
+
+    def _send(self, status, body):
+        self.send_response(status)
+        self.send_header("content-type", "text/plain")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass  # keep the repro output readable
+
+
+if __name__ == "__main__":
+    print(f"origin on :{PORT} (slow={SLOW_SECONDS}s)", flush=True)
+    try:
+        ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/repro/streamed-put-io-context/src/lib.rs
+++ b/tests/repro/streamed-put-io-context/src/lib.rs
@@ -1,0 +1,127 @@
+//! Minimal reproducer for the streamed-PUT I/O-context failure.
+//!
+//! Isolates the shape of multistore's write path with no S3, no auth and no
+//! registry, so the only variable left is *when* the inbound request body
+//! stream is touched relative to an await.
+//!
+//! Two arms, selected by path:
+//!
+//! * `/before` — attach the inbound stream to the outbound request in this
+//!   request's own I/O context, before any await. This is what
+//!   `ProxyGateway::op_needs_buffered_body` arranges for the multipart control
+//!   ops and batch delete.
+//! * `/after` — await first (standing in for the registry lookup and the STS
+//!   `AssumeRoleWithWebIdentity` exchange), *then* attach the stream. This is
+//!   what `WorkerBackend::forward` does for `PutObject` and `UploadPart`, which
+//!   the classifier explicitly excludes from the guard.
+//!
+//! On wasm32 the wasm-bindgen executor is a single queue shared by every
+//! in-flight request in the isolate, so a future parked on an await can be
+//! polled while workerd's current I/O context belongs to a *different* request.
+//! Touching this request's body stream at that moment is I/O on behalf of
+//! someone else. Drive both arms concurrently and compare.
+
+use worker::{event, Context, Env, Result};
+
+#[event(fetch)]
+async fn fetch(req: web_sys::Request, env: Env, _ctx: Context) -> Result<web_sys::Response> {
+    console_error_panic_hook::set_once();
+
+    let uri: http::Uri = req
+        .url()
+        .parse()
+        .map_err(|e| worker::Error::RustError(format!("url parse: {e}")))?;
+    let arm = uri.path().trim_matches('/').to_string();
+
+    let origin = env.var("ORIGIN_URL")?.to_string();
+    let slow = env.var("SLOW_URL")?.to_string();
+
+    // Capture the inbound stream up front, exactly as `RequestParts::from_web_sys`
+    // does before the gateway is entered. Capturing is not yet I/O; using it is.
+    let body = req.body();
+    let len = req.headers().get("content-length").ok().flatten();
+
+    let outcome = if arm == "before" {
+        let forwarded = forward(&origin, body, len).await;
+        let _ = slow_call(&slow).await;
+        forwarded
+    } else {
+        slow_call(&slow).await?;
+        forward(&origin, body, len).await
+    };
+
+    match outcome {
+        Ok(status) => text(200, &format!("ok {status}")),
+        Err(e) => {
+            // The prod symptom is an uncaught exception (edge 520). Here the
+            // worker crate surfaces it as an Err, so capture the message rather
+            // than letting it escape — the text is the whole point.
+            let msg = format!("{e}");
+            worker::console_error!("[{}] forward failed: {}", arm, msg);
+            text(599, &msg)
+        }
+    }
+}
+
+/// Attach `body` to a PUT at `origin`, mirroring `WorkerBackend::forward`,
+/// including the `FixedLengthStream` wrapper and its dropped `pipe_to` promise.
+async fn forward(
+    origin: &str,
+    body: Option<web_sys::ReadableStream>,
+    len: Option<String>,
+) -> Result<u16> {
+    let init = web_sys::RequestInit::new();
+    init.set_method("PUT");
+
+    if let Some(stream) = body {
+        match len.as_deref().and_then(|v| v.parse::<u64>().ok()) {
+            Some(n) => {
+                let fls = new_fixed_length_stream(n)
+                    .map_err(|e| rust_err("FixedLengthStream init failed", e))?;
+                let transform: &web_sys::TransformStream = fls.as_ref();
+                let _ = stream.pipe_to(&transform.writable());
+                init.set_body(&transform.readable());
+            }
+            None => init.set_body(&stream),
+        }
+    }
+
+    let ws = web_sys::Request::new_with_str_and_init(origin, &init)
+        .map_err(|e| rust_err("outbound request build failed", e))?;
+    let resp = worker::Fetch::Request(ws.into()).send().await?;
+    let resp: web_sys::Response = resp.into();
+    Ok(resp.status())
+}
+
+/// Stand-in for the awaits the gateway performs between capturing the body and
+/// forwarding it: the Source API product/connection lookup and the STS exchange.
+async fn slow_call(url: &str) -> Result<()> {
+    let init = web_sys::RequestInit::new();
+    init.set_method("GET");
+    let ws = web_sys::Request::new_with_str_and_init(url, &init)
+        .map_err(|e| rust_err("slow request build failed", e))?;
+    worker::Fetch::Request(ws.into()).send().await?;
+    Ok(())
+}
+
+/// Parts can exceed `u32::MAX`, so fall back to the BigInt constructor.
+fn new_fixed_length_stream(
+    len: u64,
+) -> std::result::Result<worker::worker_sys::FixedLengthStream, wasm_bindgen::JsValue> {
+    if len <= u32::MAX as u64 {
+        worker::worker_sys::FixedLengthStream::new(len as u32)
+    } else {
+        worker::worker_sys::FixedLengthStream::new_big_int(js_sys::BigInt::from(len))
+    }
+}
+
+fn rust_err(context: &str, e: wasm_bindgen::JsValue) -> worker::Error {
+    worker::Error::RustError(format!("{context}: {e:?}"))
+}
+
+fn text(status: u16, body: &str) -> Result<web_sys::Response> {
+    let init = web_sys::ResponseInit::new();
+    init.set_status(status);
+    web_sys::Response::new_with_opt_str_and_init(Some(body), &init)
+        .map_err(|e| rust_err("response build failed", e))
+}

--- a/tests/repro/streamed-put-io-context/wrangler.toml
+++ b/tests/repro/streamed-put-io-context/wrangler.toml
@@ -1,0 +1,10 @@
+name = "streamed-put-io-context"
+main = "build/worker/shim.mjs"
+compatibility_date = "2026-03-17"
+
+[build]
+command = "worker-build --release"
+
+[vars]
+ORIGIN_URL = "http://127.0.0.1:9101/sink"
+SLOW_URL = "http://127.0.0.1:9101/slow"


### PR DESCRIPTION
Standalone reproducer under `tests/repro/streamed-put-io-context/`. Not wired into CI — it is a manual tool and an artifact to hand upstream.

## What it isolates

No S3, no auth, no registry. One variable: whether the inbound body stream is touched **before** or **after** an await.

- `/before` — attach the stream in the request's own I/O context. Mirrors `ProxyGateway::op_needs_buffered_body`, the guard that covers the multipart control ops and batch delete.
- `/after` — await first (standing in for the registry lookup and STS exchange), then attach. Mirrors `WorkerBackend::forward` for `PutObject`/`UploadPart`, which the classifier explicitly excludes.

`forward()` copies `WorkerBackend::forward` faithfully, including the `FixedLengthStream` wrapper and its dropped `pipe_to` promise.

## Result

1 failure in 32 on `/after`, 0 in 32 on `/before`, at concurrency 8 × 16 MiB:

```
[after] forward failed: Error: Network connection lost.
```

Intermittent — a later 96/96 run was clean. A green run is inconclusive.

## Scope

`Network connection lost` maps to `BackendError` → **503**, the minority prod mode (2 of 23 in one sample). It does **not** reproduce the majority 520.

Prod evidence now shows the 520 is *relayed from the backend fetch*: `GatewayResponse::Forward` passes the upstream status through verbatim, and the worker's own 5xx log (from #201) records `status=520` with `handle_request` returning normally. tessera's backend is plain S3 in us-west-2, which does not emit 520 — so the runtime is synthesizing it for a subrequest the worker issued. That remains open.

The accompanying `TypeError: Can't read from request stream after responding with an exception` fires ~1 ms *after* the response commits — the orphaned `pipe_to` still reading the inbound body. A consequence rather than the cause, but it is what resets the connection so the client never sees the relayed status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)