### PR TITLE
fix(observability): log relayed backend identity on 5xx

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,17 +344,35 @@ async fn fetch(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys:
 
     // Production runs at LOG_LEVEL=WARN, so the `info` line above — and the
     // `info_span` carrying method/path — are both silenced. That leaves a 5xx
-    // with no worker-side record at all, which is how the edge-generated 520s on
-    // large streamed PUTs ended up undiagnosable: Cloudflare logs the URL and
-    // nothing else. Re-emit at WARN, with the span fields inlined since the span
-    // itself is disabled at this level.
+    // with no worker-side record at all, which is how the 520s on large streamed
+    // PUTs ended up undiagnosable: Cloudflare logs the URL and nothing else.
+    // Re-emit at WARN, with the span fields inlined since the span itself is
+    // disabled at this level.
+    //
+    // The response headers are the relayed *backend* headers: on a forwarded
+    // request the gateway passes the upstream status through verbatim, and
+    // `RESPONSE_HEADER_DENYLIST` strips only hop-by-hop, auth and proxy-routing
+    // names — so `server` and the `x-amz-*` ids survive. That is what
+    // distinguishes the three candidates for a relayed 520 that S3 itself never
+    // emits: `server: AmazonS3` plus a request id means S3 answered and the
+    // status is real; a `cf-ray` on the response means the subrequest's status
+    // was minted inside Cloudflare's egress path; neither means the runtime
+    // synthesised it with no upstream reply at all.
     if status >= 500 {
+        let h = response.headers();
+        let hv = |name: &str| h.get(name).ok().flatten().unwrap_or_default();
         tracing::warn!(
             status,
             duration_ms,
             method = %parts.method,
             path = %parts.path,
             content_length = header_str(&parts.headers, "content-length"),
+            resp_server = %hv("server"),
+            resp_cf_ray = %hv("cf-ray"),
+            resp_amz_request_id = %hv("x-amz-request-id"),
+            resp_amz_id_2 = %hv("x-amz-id-2"),
+            resp_content_type = %hv("content-type"),
+            resp_content_length = %hv("content-length"),
             "server error response"
         );
     }


### PR DESCRIPTION
## Why

The 5xx WARN from #201 records the status but not **who produced it**. On a forwarded request the gateway relays the upstream status verbatim (`GatewayResponse::Forward` → `response_from_forward`), so a 520 reaching the client is a 520 the backend fetch returned. Nothing in the log distinguishes the three candidates:

| shape | means |
| --- | --- |
| `server: AmazonS3` + `x-amz-request-id` | S3 answered; the status is real, and we have ids to escalate with |
| `cf-ray` on the response | minted inside Cloudflare's egress path, not by the origin |
| all empty | runtime synthesised a status with no upstream reply |

tessera's backend is plain S3 in us-west-2, which does not emit 520 — so this is the discriminator that says where it comes from.

## What

Adds the relayed response headers to the existing WARN: `server`, `cf-ray`, `x-amz-request-id`, `x-amz-id-2`, plus response content-type/length. `RESPONSE_HEADER_DENYLIST` strips only hop-by-hop, auth and proxy-routing names, so these survive the relay.

## Verified locally

Against the real bucket via `wrangler dev` + the API stub — not just compiled.

Relayed 404 from S3 reaches the client with backend identity intact:

```
HTTP/1.1 404 Not Found
Server: AmazonS3
x-amz-request-id: K63P6TH21BMK073K
x-amz-id-2: BrEuDBga6nt5PCpMTU6T7UzLnirhFf47GDG3V59M4njPKOwK7Uu6Cux...
```

Proxy-generated 500 (control-plane `err-500` probe) logs the contrasting shape:

```
[WARN] server error response { status=500, duration_ms=32.0, method=GET,
  path=/ci-tests/err-500/some-key.bin, resp_server=, resp_cf_ray=,
  resp_amz_request_id=, resp_content_type=application/xml }
```

Empty `server` + our own XML vs. `AmazonS3` + a request id — the two shapes are distinguishable, which is the point.

## Status

Diagnostic only, no behaviour change. This does **not** answer why the 520 happens; it narrows where to look next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)