### PR TITLE
fix(registry): honor a data connection's explicit S3 endpoint

### DIFF
--- a/src/source_api/registry.rs
+++ b/src/source_api/registry.rs
@@ -4,11 +4,8 @@ use multistore::api::response::BucketEntry;
 use multistore::error::ProxyError;
 use multistore::registry::{BucketRegistry, ResolvedBucket};
 use multistore::types::{Action, BucketConfig, ResolvedIdentity, S3Operation};
-use std::collections::HashMap;
 
 use crate::authz::{decide_backend_auth, is_write_action};
-
-use super::types::DataConnectionDetails;
 
 /// Registry that resolves Source Cooperative products to multistore `BucketConfig`s
 /// by calling the Source Cooperative API.
@@ -165,7 +162,7 @@ async fn resolve_product(
     .await?;
 
     // 4. Build BucketConfig
-    let (backend_type, mut backend_options) = build_backend_options(&connection.details)?;
+    let (backend_type, mut backend_options) = connection.details.backend_options()?;
 
     // A write needs the caller's product permissions; fetch them only for an
     // authenticated write, since reads never consult them and an anonymous write
@@ -251,53 +248,4 @@ async fn resolve_product(
     );
 
     Ok(config)
-}
-
-/// Map a connection's raw `provider` to its multistore `backend_type`
-/// (`s3`/`az`/`gcs`) and the provider-specific `backend_options`. Doing the
-/// provider match once keeps the type and its options in a single source of
-/// truth. The GCS arm sets `bucket_name` (multistore's GCS store requires it,
-/// same as the s3 arm).
-fn build_backend_options(
-    details: &DataConnectionDetails,
-) -> Result<(String, HashMap<String, String>), ProxyError> {
-    let mut options = HashMap::new();
-    let backend_type = match details.provider.as_str() {
-        "s3" => {
-            if let Some(ref bucket) = details.bucket {
-                options.insert("bucket_name".to_string(), bucket.clone());
-            }
-            if let Some(ref region) = details.region {
-                options.insert("region".to_string(), region.clone());
-                options.insert(
-                    "endpoint".to_string(),
-                    format!("https://s3.{}.amazonaws.com", region),
-                );
-            }
-            "s3"
-        }
-        "az" | "azure" => {
-            if let Some(ref account_name) = details.account_name {
-                options.insert("account_name".to_string(), account_name.clone());
-            }
-            if let Some(ref container) = details.container_name {
-                options.insert("container_name".to_string(), container.clone());
-            }
-            "az"
-        }
-        "gcs" | "gs" => {
-            if let Some(ref bucket) = details.bucket {
-                options.insert("bucket_name".to_string(), bucket.clone());
-            }
-            "gcs"
-        }
-        other => {
-            return Err(ProxyError::Internal(format!(
-                "unsupported provider: {}",
-                other
-            )))
-        }
-    }
-    .to_string();
-    Ok((backend_type, options))
 }

--- a/src/source_api/types.rs
+++ b/src/source_api/types.rs
@@ -2,6 +2,7 @@
 //! and cached in [`super::cache`] and resolved into multistore `BucketConfig`s
 //! by [`super::registry`].
 
+use multistore::error::ProxyError;
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -73,6 +74,65 @@ pub struct DataConnectionDetails {
     pub base_prefix: Option<String>,
     pub account_name: Option<String>,
     pub container_name: Option<String>,
+    /// Explicit S3 endpoint for a non-AWS, S3-compatible backend (Cloudflare
+    /// R2, MinIO, Ceph). When absent the endpoint is derived from `region`.
+    pub endpoint: Option<String>,
+}
+
+impl DataConnectionDetails {
+    /// Map the raw `provider` to its multistore `backend_type` (`s3`/`az`/`gcs`)
+    /// and the provider-specific `backend_options`. Doing the provider match
+    /// once keeps the type and its options in a single source of truth. The GCS
+    /// arm sets `bucket_name` (multistore's GCS store requires it, same as the
+    /// s3 arm).
+    pub fn backend_options(&self) -> Result<(String, HashMap<String, String>), ProxyError> {
+        let mut options = HashMap::new();
+        let backend_type = match self.provider.as_str() {
+            "s3" => {
+                if let Some(ref bucket) = self.bucket {
+                    options.insert("bucket_name".to_string(), bucket.clone());
+                }
+                if let Some(ref region) = self.region {
+                    options.insert("region".to_string(), region.clone());
+                }
+                // An explicit endpoint wins: S3-compatible backends (R2 and
+                // friends) carry `region: "auto"`, which derives the
+                // unresolvable `https://s3.auto.amazonaws.com` and fails the
+                // backend fetch at DNS (Cloudflare 1016 → a 530 to the client).
+                if let Some(endpoint) = self.endpoint.clone().or_else(|| {
+                    self.region
+                        .as_ref()
+                        .map(|region| format!("https://s3.{}.amazonaws.com", region))
+                }) {
+                    options.insert("endpoint".to_string(), endpoint);
+                }
+                "s3"
+            }
+            "az" | "azure" => {
+                if let Some(ref account_name) = self.account_name {
+                    options.insert("account_name".to_string(), account_name.clone());
+                }
+                if let Some(ref container) = self.container_name {
+                    options.insert("container_name".to_string(), container.clone());
+                }
+                "az"
+            }
+            "gcs" | "gs" => {
+                if let Some(ref bucket) = self.bucket {
+                    options.insert("bucket_name".to_string(), bucket.clone());
+                }
+                "gcs"
+            }
+            other => {
+                return Err(ProxyError::Internal(format!(
+                    "unsupported provider: {}",
+                    other
+                )))
+            }
+        }
+        .to_string();
+        Ok((backend_type, options))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -80,3 +80,40 @@ fn product_list_wrapper_parses() {
     let l: SourceProductList = serde_json::from_str(&json).unwrap();
     assert_eq!(l.products.len(), 1);
 }
+
+// ── backend_options: provider → (backend_type, multistore options) ──────────
+
+fn details(json: &str) -> types::DataConnectionDetails {
+    serde_json::from_str(json).unwrap()
+}
+
+#[test]
+fn s3_endpoint_derived_from_region_when_absent() {
+    let (backend_type, opts) = details(r#"{"provider":"s3","bucket":"b","region":"us-west-2"}"#)
+        .backend_options()
+        .unwrap();
+    assert_eq!(backend_type, "s3");
+    assert_eq!(opts["endpoint"], "https://s3.us-west-2.amazonaws.com");
+    assert_eq!(opts["region"], "us-west-2");
+    assert_eq!(opts["bucket_name"], "b");
+}
+
+#[test]
+fn explicit_endpoint_wins_over_region() {
+    // An S3-compatible connection (Cloudflare R2) carries region "auto"; deriving
+    // the endpoint from it yields the unresolvable https://s3.auto.amazonaws.com
+    // and every backend fetch dies at DNS (Cloudflare 1016 → 530 to the client).
+    let (_, opts) = details(
+        r#"{"provider":"s3","bucket":"b","region":"auto",
+            "endpoint":"https://acct.r2.cloudflarestorage.com"}"#,
+    )
+    .backend_options()
+    .unwrap();
+    assert_eq!(opts["endpoint"], "https://acct.r2.cloudflarestorage.com");
+    assert_eq!(opts["region"], "auto");
+}
+
+#[test]
+fn unsupported_provider_errors() {
+    assert!(details(r#"{"provider":"ftp"}"#).backend_options().is_err());
+}

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -28,8 +28,9 @@ REAL_API = "https://source.coop"
 # connection — exactly the drift we want an early warning for.
 KNOWN_AUTH_TYPES = {"unsigned", "s3_web_identity_role"}
 
-# Providers the proxy's build_backend_options maps (src/source_api/registry.rs,
-# closed match). Anything else is ProxyError::Internal on every request.
+# Providers DataConnectionDetails::backend_options maps
+# (src/source_api/types.rs, closed match). Anything else is
+# ProxyError::Internal on every request.
 KNOWN_PROVIDERS = {"s3", "az", "azure", "gcs", "gs"}
 
 


### PR DESCRIPTION
## Problem

Every object read through an S3-compatible (non-AWS) data connection returns **530**:

```
[WARN] source_data_proxy: server error response { status=530, method=HEAD,
  path=/alukach/r2-data/README.md, resp_server=cloudflare, resp_content_type=text/plain,
  resp_content_length=17 }
```

A 17-byte `text/plain` body from `server: cloudflare` on the worker's *subrequest* leg is `error code: 1016` — origin DNS failure. The proxy was fetching a hostname that does not exist.

`DataConnectionDetails` (`src/source_api/types.rs`) had no `endpoint` field, so serde dropped the connection's endpoint on the floor and the s3 arm of `build_backend_options` always synthesized the backend URL from `region`:

```rust
options.insert("endpoint".to_string(), format!("https://s3.{}.amazonaws.com", region));
```

The control plane stores Cloudflare R2 connections as `region: "auto"` plus an explicit endpoint:

```json
{"provider":"s3","bucket":"r2-data-connection-test","region":"auto",
 "endpoint":"https://<account>.r2.cloudflarestorage.com"}
```

so the proxy resolved `https://s3.auto.amazonaws.com` — NXDOMAIN — on every request. (#210 assumed a custom endpoint was already honored; it was not.)

## Change

- `DataConnectionDetails` deserializes `endpoint`, and the s3 arm prefers it, falling back to the region-derived AWS endpoint when absent. AWS connections are unaffected: no `endpoint` on the record means the derived URL, byte-identical to before.
- `build_backend_options` moves from `registry.rs` onto `DataConnectionDetails` as `backend_options()`. `registry.rs` is wasm-only (it pulls `super::cache`, which needs `worker`), so nothing in it can be unit-tested natively; `types.rs` is already `#[path]`-included by `tests/fixtures.rs`. The move is what makes the branch testable.

## Tests

Three cases in `tests/fixtures.rs`: endpoint derived from region when absent, explicit endpoint wins over `region: "auto"`, unsupported provider still errors. `cargo test` (76 tests), `cargo clippy --target wasm32-unknown-unknown -- -D warnings`, and `cargo fmt --check` all pass.

## Still needed for R2 end-to-end

This fixes the address, not the credentials. The connection above has no `authentication`, so the proxy signs nothing and R2 rejects the anonymous request unless the bucket is public. Signed R2 access needs the `s3_access_key` backend-auth variant — tracked in #210, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)