### PR TITLE
ci: run cargo audit on a schedule and open a fix PR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,75 @@
+name: Security Audit
+
+# The `audit` job in ci.yml only runs on push/PR, so a new RustSec advisory
+# against an unchanged dependency goes unnoticed until someone happens to open
+# a PR. This runs the same check on a schedule and hands a red result to Claude
+# to fix, the way #214 (h2 / RUSTSEC-2026-0258) was fixed by hand.
+
+on:
+  schedule:
+    # ponytail: every other day-of-month, so the 31st→1st gap runs back to
+    # back. Harmless for a dedupe-guarded job; switch to a weekday list if it
+    # ever matters.
+    - cron: "0 7 */2 * *"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Scheduled Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: cargo audit
+        id: audit
+        continue-on-error: true
+        run: cargo audit
+
+      - name: Open a fix PR
+        if: steps.audit.outcome == 'failure'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(cargo audit),Bash(cargo update:*),Bash(cargo tree:*),Bash(cargo check:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr list:*),Bash(gh pr create:*),Bash(gh pr view:*)"
+          prompt: |
+            `cargo audit` is failing on the default branch.
+
+            First run `gh pr list --state open --search "cargo audit in:title"`. If a PR
+            for these same advisories is already open, stop and do nothing.
+
+            Otherwise: run `cargo audit` to see the advisories and fix them. Prefer
+            `cargo update -p <crate>`; bump the version in Cargo.toml only if the
+            lockfile alone can't reach a patched release. If an advisory has no fixed
+            version (unmaintained or unsound crates), or the fix needs a transitive
+            dependency we don't control, don't force it — open the PR with whatever you
+            could fix and say plainly in the description what is left and why.
+
+            Verify both `cargo audit` and `cargo check --target wasm32-unknown-unknown`
+            pass before opening the PR.
+
+            Then create a branch `claude/audit-<advisory-id>` off the default branch,
+            commit as `fix(deps): <what you bumped> for <RUSTSEC-id>`, push, read
+            `.github/pull_request_template.md`, fill each section (removing the HTML
+            comment instructions), write it to a temp file and run
+            `gh pr create --body-file <path>`. Title the PR so it contains the words
+            "cargo audit", so the dedupe check above finds it next run.
+
+      - name: Fail the run
+        # A red run is the visible alarm; the PR above is the fix. Same reason
+        # contract.yml stays red instead of quietly filing and passing.
+        if: steps.audit.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## What I'm changing

Adds `.github/workflows/audit.yml`: a scheduled `cargo audit` run every other
day that hands a red result to `claude-code-action` to fix and open a PR.

The `audit` job in `ci.yml` only fires on `push`/`pull_request`, so a new
RustSec advisory filed against a dependency we haven't touched sits unnoticed
until somebody happens to open a PR. #214 (h2 / RUSTSEC-2026-0258) was exactly
that shape, found and fixed by hand.

## How I did it

Reuses two patterns already in the repo rather than adding anything new:

- The scheduled-check-plus-failure-handler shape from `contract.yml`, including
  letting the run go red — a live advisory with a green scheduled run is a
  silent alarm.
- The `claude-code-action@v1` invocation and the branch → template → `gh pr
  create` instructions from `claude.yml`, in automation mode (`prompt:`) rather
  than tag mode.

The prompt is deliberately conservative:

- It checks `gh pr list --search "cargo audit in:title"` first and stops if a
  fix PR is already open, so a repeated failure doesn't stack duplicate PRs.
- It must verify both `cargo audit` and `cargo check --target
  wasm32-unknown-unknown` pass before opening the PR, so a `cargo update` that
  breaks the wasm build doesn't reach review.
- Advisories with no fixed version (unmaintained/unsound crates, or transitive
  deps we don't control) are explicitly not to be forced — it opens the PR with
  what it could fix and says what's left.

`--allowedTools` is scoped to the cargo/git/gh commands the job actually needs.

## How to test it

`workflow_dispatch` is enabled, so: **Actions → Security Audit → Run workflow**.
`cargo audit` passes on `main` today, so a manual run should be green and skip
the Claude step entirely. To exercise the fix path, temporarily pin a crate with
a known advisory on a scratch branch and dispatch from there.

## PR Checklist

- [x] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] This PR affects the [Source Cooperative Frontend & API](https://github.com/source-cooperative/source.coop),
      and I have opened issue/PR #XXX to track the change.

Not applicable — CI-only change, no test surface and no frontend/API impact.

## Related Issues

None. Note for the reviewer: the 14 open Dependabot alerts on this repo are all
npm, not cargo, so they are a separate gap this workflow does not close.
